### PR TITLE
feat: add dashboard stats with charts

### DIFF
--- a/backend/controllers/statsController.js
+++ b/backend/controllers/statsController.js
@@ -1,0 +1,33 @@
+const User = require('../models/User');
+const Project = require('../models/Project');
+const VCard = require('../models/Vcard');
+
+/**
+ * Get aggregated statistics for the super admin dashboard.
+ */
+exports.getStats = async (_req, res) => {
+  try {
+    const [totalUsers, totalProjects, totalVCards, adminCount, superAdminCount, userCount] = await Promise.all([
+      User.count(),
+      Project.count(),
+      VCard.count(),
+      User.count({ where: { role: 'admin' } }),
+      User.count({ where: { role: 'superAdmin' } }),
+      User.count({ where: { role: 'user' } })
+    ]);
+
+    res.json({
+      totalUsers,
+      totalProjects,
+      totalVCards,
+      usersByRole: {
+        admin: adminCount,
+        superAdmin: superAdminCount,
+        user: userCount
+      }
+    });
+  } catch (error) {
+    res.status(500).json({ error: 'Failed to fetch stats' });
+  }
+};
+

--- a/backend/index.js
+++ b/backend/index.js
@@ -18,6 +18,7 @@ const LimitsRoutes = require('./routes/LimiteRoutes');
 const projectRoutes = require('./routes/projectRoutes');
 const pixelRoutes = require('./routes/pixelRoutes');
 const customDomainRoutes = require('./routes/customDomainRoutes');
+const statsRoutes = require('./routes/statsRoutes');
 const sequelize = require('./database/sequelize');
 const { requireAuth } = require('./middleware/authMiddleware');
 const path = require("path");
@@ -165,6 +166,7 @@ app.use('/limits', LimitsRoutes);
 app.use('/project', projectRoutes);
 app.use('/pixel', pixelRoutes);
 app.use('/custom-domain', customDomainRoutes);
+app.use('/', statsRoutes);
 
 app.get('/', (_req, res) => {
   res.send('Welcome to the User Management API!');

--- a/backend/routes/statsRoutes.js
+++ b/backend/routes/statsRoutes.js
@@ -1,0 +1,9 @@
+const express = require('express');
+const router = express.Router();
+const statsController = require('../controllers/statsController');
+const { requireAuthSuperAdmin, requireSuperAdmin } = require('../middleware/authMiddleware');
+
+router.get('/superadmin/stats', requireAuthSuperAdmin, requireSuperAdmin, statsController.getStats);
+
+module.exports = router;
+

--- a/frontend/src/pagesSuperAdmin/DashboardAdmin.tsx
+++ b/frontend/src/pagesSuperAdmin/DashboardAdmin.tsx
@@ -1,10 +1,129 @@
-import MainPanel from "../templateBack/MainPanel";
+import { useEffect, useState } from 'react';
+import { Pie } from 'react-chartjs-2';
+import { Chart as ChartJS, ArcElement, Tooltip, Legend } from 'chart.js';
+import { api } from '../services/api';
+
+ChartJS.register(ArcElement, Tooltip, Legend);
+
+interface Stats {
+  totalUsers: number;
+  totalProjects: number;
+  totalVCards: number;
+  usersByRole: {
+    admin: number;
+    superAdmin: number;
+    user: number;
+  };
+}
 
 const DashboardAdmin = () => {
+  const [stats, setStats] = useState<Stats | null>(null);
+
+  useEffect(() => {
+    api
+      .get('/superadmin/stats')
+      .then((res) => setStats(res.data))
+      .catch((err) => console.error('Failed to load stats', err));
+  }, []);
 
   return (
-    <div>
-      <MainPanel/>
+    <div className="page-container w-full">
+      <h2 className="my-6 text-2xl font-semibold text-gray-700 dark:text-gray-200">
+        Dashboard
+      </h2>
+      <div className="grid gap-6 mb-8 md:grid-cols-2 xl:grid-cols-4">
+        <div className="flex items-center p-4 bg-white rounded-lg shadow-xs dark:bg-gray-800">
+          <div className="p-3 mr-4 text-orange-500 bg-orange-100 rounded-full dark:text-orange-100 dark:bg-orange-500">
+            <svg className="w-5 h-5" fill="currentColor" viewBox="0 0 20 20">
+              <path d="M13 6a3 3 0 11-6 0 3 3 0 016 0zM18 8a2 2 0 11-4 0 2 2 0 014 0zM14 15a4 4 0 00-8 0v3h8v-3zM6 8a2 2 0 11-4 0 2 2 0 014 0zM16 18v-3a5.972 5.972 0 00-.75-2.906A3.005 3.005 0 0119 15v3h-3zM4.75 12.094A5.973 5.973 0 004 15v3H1v-3a3 3 0 013.75-2.906z" />
+            </svg>
+          </div>
+          <div>
+            <p className="mb-2 text-sm font-medium text-gray-600 dark:text-gray-400">
+              Total users
+            </p>
+            <p className="text-lg font-semibold text-gray-700 dark:text-gray-200">
+              {stats?.totalUsers ?? 0}
+            </p>
+          </div>
+        </div>
+        <div className="flex items-center p-4 bg-white rounded-lg shadow-xs dark:bg-gray-800">
+          <div className="p-3 mr-4 text-green-500 bg-green-100 rounded-full dark:text-green-100 dark:bg-green-500">
+            <svg className="w-5 h-5" fill="currentColor" viewBox="0 0 20 20">
+              <path
+                fillRule="evenodd"
+                d="M4 4a2 2 0 00-2 2v4a2 2 0 002 2V6h10a2 2 0 00-2-2H4zm2 6a2 2 0 012-2h8a2 2 0 012 2v4a2 2 0 01-2 2H8a2 2 0 01-2-2v-4zm6 4a2 2 0 100-4 2 2 0 000 4z"
+                clipRule="evenodd"
+              />
+            </svg>
+          </div>
+          <div>
+            <p className="mb-2 text-sm font-medium text-gray-600 dark:text-gray-400">
+              Total projects
+            </p>
+            <p className="text-lg font-semibold text-gray-700 dark:text-gray-200">
+              {stats?.totalProjects ?? 0}
+            </p>
+          </div>
+        </div>
+        <div className="flex items-center p-4 bg-white rounded-lg shadow-xs dark:bg-gray-800">
+          <div className="p-3 mr-4 text-blue-500 bg-blue-100 rounded-full dark:text-blue-100 dark:bg-blue-500">
+            <svg className="w-5 h-5" fill="currentColor" viewBox="0 0 20 20">
+              <path d="M3 1a1 1 0 000 2h1.22l.305 1.222a.997.997 0 00.01.042l1.358 5.43-.893.892C3.74 11.846 4.632 14 6.414 14H15a1 1 0 000-2H6.414l1-1H14a1 1 0 00.894-.553l3-6A1 1 0 0017 3H6.28l-.31-1.243A1 1 0 005 1H3zM16 16.5a1.5 1.5 0 11-3 0 1.5 1.5 0 013 0zM6.5 18a1.5 1.5 0 100-3 1.5 1.5 0 000 3z" />
+            </svg>
+          </div>
+          <div>
+            <p className="mb-2 text-sm font-medium text-gray-600 dark:text-gray-400">
+              Total vCards
+            </p>
+            <p className="text-lg font-semibold text-gray-700 dark:text-gray-200">
+              {stats?.totalVCards ?? 0}
+            </p>
+          </div>
+        </div>
+        <div className="flex items-center p-4 bg-white rounded-lg shadow-xs dark:bg-gray-800">
+          <div className="p-3 mr-4 text-teal-500 bg-teal-100 rounded-full dark:text-teal-100 dark:bg-teal-500">
+            <svg className="w-5 h-5" fill="currentColor" viewBox="0 0 20 20">
+              <path
+                fillRule="evenodd"
+                d="M18 5v8a2 2 0 01-2 2h-5l-5 4v-4H4a2 2 0 01-2-2V5a2 2 0 012-2h12a2 2 0 012 2zM7 8H5v2h2V8zm2 0h2v2H9V8zm6 0h-2v2h2V8z"
+                clipRule="evenodd"
+              />
+            </svg>
+          </div>
+          <div>
+            <p className="mb-2 text-sm font-medium text-gray-600 dark:text-gray-400">
+              Super admins
+            </p>
+            <p className="text-lg font-semibold text-gray-700 dark:text-gray-200">
+              {stats?.usersByRole?.superAdmin ?? 0}
+            </p>
+          </div>
+        </div>
+      </div>
+
+      {stats && (
+        <div className="p-4 mb-8 bg-white rounded-lg shadow-xs dark:bg-gray-800">
+          <h3 className="mb-4 text-lg font-semibold text-gray-700 dark:text-gray-200">
+            Users by role
+          </h3>
+          <Pie
+            data={{
+              labels: ['Admin', 'Super Admin', 'User'],
+              datasets: [
+                {
+                  data: [
+                    stats.usersByRole.admin,
+                    stats.usersByRole.superAdmin,
+                    stats.usersByRole.user,
+                  ],
+                  backgroundColor: ['#f97316', '#6366f1', '#10b981'],
+                },
+              ],
+            }}
+          />
+        </div>
+      )}
     </div>
   );
 };

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -10,7 +10,7 @@ import { CustomDomain, DNSInstructions } from './CustomDomain';
 import { Quote, QuoteService as QuoteServiceEnum } from './Quote';
 import { VCard } from './vcard';
 
-const api = axios.create({
+export const api = axios.create({
   baseURL: import.meta.env.VITE_API_BASE_URL || 'http://localhost:3000',
   // Allow the API timeout to be configured via environment variable and
   // fall back to a generous default to avoid premature request aborts.


### PR DESCRIPTION
## Summary
- show total users, projects, vCards, and super-admin count on dashboard
- visualize user role distribution via Chart.js pie chart
- keep default MainPanel template for non-super-admin pages
- ensure dashboard stats requests include auth token and valid SVG path

## Testing
- `npm test --prefix backend` *(fails: Error: no test specified)*
- `npm test --prefix frontend` *(fails: Missing script: test)*
- `npm run lint --prefix frontend` *(fails: 124 errors, 17 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_689dc4d260bc832fbf0ef85258e55556