### PR TITLE
fix dashboard chart errors by removing unused scripts and correcting icon path

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -34,9 +34,6 @@
         <script src="src/assets/styleTemplate/js/main.js"></script>
         <script src="https://cdn.jsdelivr.net/gh/alpinejs/alpine@v2.x.x/dist/alpine.min.js" defer></script>
         <script src="src/assets/styleBack/js/init-alpine.js"></script>
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/2.9.3/Chart.min.js" defer ></script>
-        <script src="src/assets/styleBack/js/charts-lines.js" defer></script>
-        <script src="src/assets/styleBack/js/charts-pie.js" defer></script>
     </div>
   </body>
 </html>

--- a/frontend/src/pagesSuperAdmin/DashboardAdmin.tsx
+++ b/frontend/src/pagesSuperAdmin/DashboardAdmin.tsx
@@ -35,7 +35,7 @@ const DashboardAdmin = () => {
         <div className="flex items-center p-4 bg-white rounded-lg shadow-xs dark:bg-gray-800">
           <div className="p-3 mr-4 text-orange-500 bg-orange-100 rounded-full dark:text-orange-100 dark:bg-orange-500">
             <svg className="w-5 h-5" fill="currentColor" viewBox="0 0 20 20">
-              <path d="M13 6a3 3 0 11-6 0 3 3 0 016 0zM18 8a2 2 0 11-4 0 2 2 0 014 0zM14 15a4 4 0 00-8 0v3h8v-3zM6 8a2 2 0 11-4 0 2 2 0 014 0zM16 18v-3a5.972 5.972 0 00-.75-2.906A3.005 3.005 0 0119 15v3h-3zM4.75 12.094A5.973 5.973 0 004 15v3H1v-3a3 3 0 013 .75-2.906z" />
+              <path d="M13 6a3 3 0 11-6 0 3 3 0 016 0zM18 8a2 2 0 11-4 0 2 2 0 014 0zM14 15a4 4 0 00-8 0v3h8v-3zM6 8a2 2 0 11-4 0 2 2 0 014 0zM16 18v-3a5.972 5.972 0 00-.75-2.906A3.005 3.005 0 0119 15v3h-3zM4.75 12.094A5.973 5.973 0 004 15v3H1v-3a3 3 0 013.75-2.906z" />
             </svg>
           </div>
           <div>


### PR DESCRIPTION
## Summary
- fix invalid SVG path in super admin dashboard user icon
- remove Chart.js template scripts to prevent console errors

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 141 problems (124 errors, 17 warnings))*


------
https://chatgpt.com/codex/tasks/task_e_689dd012a434832f997ff70b8d3c9acf