### PR TITLE
feat: add CRM models, controller, and routes

### DIFF
--- a/backend/controllers/crmController.js
+++ b/backend/controllers/crmController.js
@@ -1,0 +1,198 @@
+const Customer = require('../models/Customer');
+const Lead = require('../models/Lead');
+const Interaction = require('../models/Interaction');
+
+// Customer CRUD
+const createCustomer = async (req, res) => {
+  try {
+    const customer = await Customer.create(req.body);
+    res.status(201).json(customer);
+  } catch (error) {
+    res.status(500).json({ error: 'Server error', details: error.message });
+  }
+};
+
+const getCustomers = async (_req, res) => {
+  try {
+    const customers = await Customer.findAll();
+    res.json(customers);
+  } catch (error) {
+    res.status(500).json({ error: 'Server error', details: error.message });
+  }
+};
+
+const getCustomerById = async (req, res) => {
+  try {
+    const customer = await Customer.findByPk(req.params.id);
+    if (!customer) {
+      return res.status(404).json({ error: 'Customer not found' });
+    }
+    res.json(customer);
+  } catch (error) {
+    res.status(500).json({ error: 'Server error', details: error.message });
+  }
+};
+
+const updateCustomer = async (req, res) => {
+  try {
+    const [updated] = await Customer.update(req.body, {
+      where: { id: req.params.id }
+    });
+    if (!updated) {
+      return res.status(404).json({ error: 'Customer not found' });
+    }
+    const updatedCustomer = await Customer.findByPk(req.params.id);
+    res.json(updatedCustomer);
+  } catch (error) {
+    res.status(500).json({ error: 'Server error', details: error.message });
+  }
+};
+
+const deleteCustomer = async (req, res) => {
+  try {
+    const customer = await Customer.findByPk(req.params.id);
+    if (!customer) {
+      return res.status(404).json({ error: 'Customer not found' });
+    }
+    await customer.destroy();
+    res.status(204).end();
+  } catch (error) {
+    res.status(500).json({ error: 'Server error', details: error.message });
+  }
+};
+
+// Lead CRUD
+const createLead = async (req, res) => {
+  try {
+    const lead = await Lead.create(req.body);
+    res.status(201).json(lead);
+  } catch (error) {
+    res.status(500).json({ error: 'Server error', details: error.message });
+  }
+};
+
+const getLeads = async (_req, res) => {
+  try {
+    const leads = await Lead.findAll();
+    res.json(leads);
+  } catch (error) {
+    res.status(500).json({ error: 'Server error', details: error.message });
+  }
+};
+
+const getLeadById = async (req, res) => {
+  try {
+    const lead = await Lead.findByPk(req.params.id);
+    if (!lead) {
+      return res.status(404).json({ error: 'Lead not found' });
+    }
+    res.json(lead);
+  } catch (error) {
+    res.status(500).json({ error: 'Server error', details: error.message });
+  }
+};
+
+const updateLead = async (req, res) => {
+  try {
+    const [updated] = await Lead.update(req.body, {
+      where: { id: req.params.id }
+    });
+    if (!updated) {
+      return res.status(404).json({ error: 'Lead not found' });
+    }
+    const updatedLead = await Lead.findByPk(req.params.id);
+    res.json(updatedLead);
+  } catch (error) {
+    res.status(500).json({ error: 'Server error', details: error.message });
+  }
+};
+
+const deleteLead = async (req, res) => {
+  try {
+    const lead = await Lead.findByPk(req.params.id);
+    if (!lead) {
+      return res.status(404).json({ error: 'Lead not found' });
+    }
+    await lead.destroy();
+    res.status(204).end();
+  } catch (error) {
+    res.status(500).json({ error: 'Server error', details: error.message });
+  }
+};
+
+// Interaction CRUD
+const createInteraction = async (req, res) => {
+  try {
+    const interaction = await Interaction.create(req.body);
+    res.status(201).json(interaction);
+  } catch (error) {
+    res.status(500).json({ error: 'Server error', details: error.message });
+  }
+};
+
+const getInteractions = async (_req, res) => {
+  try {
+    const interactions = await Interaction.findAll();
+    res.json(interactions);
+  } catch (error) {
+    res.status(500).json({ error: 'Server error', details: error.message });
+  }
+};
+
+const getInteractionById = async (req, res) => {
+  try {
+    const interaction = await Interaction.findByPk(req.params.id);
+    if (!interaction) {
+      return res.status(404).json({ error: 'Interaction not found' });
+    }
+    res.json(interaction);
+  } catch (error) {
+    res.status(500).json({ error: 'Server error', details: error.message });
+  }
+};
+
+const updateInteraction = async (req, res) => {
+  try {
+    const [updated] = await Interaction.update(req.body, {
+      where: { id: req.params.id }
+    });
+    if (!updated) {
+      return res.status(404).json({ error: 'Interaction not found' });
+    }
+    const updatedInteraction = await Interaction.findByPk(req.params.id);
+    res.json(updatedInteraction);
+  } catch (error) {
+    res.status(500).json({ error: 'Server error', details: error.message });
+  }
+};
+
+const deleteInteraction = async (req, res) => {
+  try {
+    const interaction = await Interaction.findByPk(req.params.id);
+    if (!interaction) {
+      return res.status(404).json({ error: 'Interaction not found' });
+    }
+    await interaction.destroy();
+    res.status(204).end();
+  } catch (error) {
+    res.status(500).json({ error: 'Server error', details: error.message });
+  }
+};
+
+module.exports = {
+  createCustomer,
+  getCustomers,
+  getCustomerById,
+  updateCustomer,
+  deleteCustomer,
+  createLead,
+  getLeads,
+  getLeadById,
+  updateLead,
+  deleteLead,
+  createInteraction,
+  getInteractions,
+  getInteractionById,
+  updateInteraction,
+  deleteInteraction
+};

--- a/backend/index.js
+++ b/backend/index.js
@@ -17,6 +17,7 @@ const notificationRoutes = require('./routes/notificationRoutes');
 const LimitsRoutes = require('./routes/LimiteRoutes');
 const projectRoutes = require('./routes/projectRoutes');
 const pixelRoutes = require('./routes/pixelRoutes');
+const crmRoutes = require('./routes/crmRoutes');
 const customDomainRoutes = require('./routes/customDomainRoutes');
 const statsRoutes = require('./routes/statsRoutes');
 const sequelize = require('./database/sequelize');
@@ -165,6 +166,7 @@ app.use('/notification', notificationRoutes);
 app.use('/limits', LimitsRoutes);
 app.use('/project', projectRoutes);
 app.use('/pixel', pixelRoutes);
+app.use('/crm', requireAuth, crmRoutes);
 app.use('/custom-domain', customDomainRoutes);
 app.use('/', statsRoutes);
 

--- a/backend/models/Customer.js
+++ b/backend/models/Customer.js
@@ -1,0 +1,57 @@
+const { DataTypes } = require('sequelize');
+const sequelize = require('../database/sequelize');
+
+const Customer = sequelize.define('Customer', {
+  id: {
+    type: DataTypes.INTEGER,
+    primaryKey: true,
+    autoIncrement: true
+  },
+  name: {
+    type: DataTypes.STRING,
+    allowNull: false
+  },
+  email: {
+    type: DataTypes.STRING,
+    allowNull: true
+  },
+  phone: {
+    type: DataTypes.STRING,
+    allowNull: true
+  },
+  status: {
+    type: DataTypes.STRING,
+    allowNull: true
+  },
+  userId: {
+    type: DataTypes.INTEGER,
+    allowNull: false,
+    references: {
+      model: 'users',
+      key: 'id'
+    }
+  },
+  notes: {
+    type: DataTypes.TEXT,
+    allowNull: true
+  }
+}, {
+  tableName: 'customers',
+  timestamps: true,
+  createdAt: 'created_at',
+  updatedAt: 'updated_at'
+});
+
+Customer.associate = (models) => {
+  Customer.belongsTo(models.Users, {
+    foreignKey: 'userId',
+    as: 'Users'
+  });
+  Customer.hasMany(models.Interaction, {
+    foreignKey: 'customerId',
+    as: 'Interactions',
+    onDelete: 'CASCADE'
+  });
+};
+
+module.exports = Customer;

--- a/backend/models/Interaction.js
+++ b/backend/models/Interaction.js
@@ -1,0 +1,68 @@
+const { DataTypes } = require('sequelize');
+const sequelize = require('../database/sequelize');
+
+const Interaction = sequelize.define('Interaction', {
+  id: {
+    type: DataTypes.INTEGER,
+    primaryKey: true,
+    autoIncrement: true
+  },
+  type: {
+    type: DataTypes.STRING,
+    allowNull: false
+  },
+  date: {
+    type: DataTypes.DATE,
+    defaultValue: DataTypes.NOW
+  },
+  notes: {
+    type: DataTypes.TEXT,
+    allowNull: true
+  },
+  userId: {
+    type: DataTypes.INTEGER,
+    allowNull: false,
+    references: {
+      model: 'users',
+      key: 'id'
+    }
+  },
+  customerId: {
+    type: DataTypes.INTEGER,
+    allowNull: true,
+    references: {
+      model: 'customers',
+      key: 'id'
+    }
+  },
+  leadId: {
+    type: DataTypes.INTEGER,
+    allowNull: true,
+    references: {
+      model: 'leads',
+      key: 'id'
+    }
+  }
+}, {
+  tableName: 'interactions',
+  timestamps: true,
+  createdAt: 'created_at',
+  updatedAt: 'updated_at'
+});
+
+Interaction.associate = (models) => {
+  Interaction.belongsTo(models.Users, {
+    foreignKey: 'userId',
+    as: 'Users'
+  });
+  Interaction.belongsTo(models.Customer, {
+    foreignKey: 'customerId',
+    as: 'Customer'
+  });
+  Interaction.belongsTo(models.Lead, {
+    foreignKey: 'leadId',
+    as: 'Lead'
+  });
+};
+
+module.exports = Interaction;

--- a/backend/models/Lead.js
+++ b/backend/models/Lead.js
@@ -1,0 +1,57 @@
+const { DataTypes } = require('sequelize');
+const sequelize = require('../database/sequelize');
+
+const Lead = sequelize.define('Lead', {
+  id: {
+    type: DataTypes.INTEGER,
+    primaryKey: true,
+    autoIncrement: true
+  },
+  name: {
+    type: DataTypes.STRING,
+    allowNull: false
+  },
+  email: {
+    type: DataTypes.STRING,
+    allowNull: true
+  },
+  phone: {
+    type: DataTypes.STRING,
+    allowNull: true
+  },
+  status: {
+    type: DataTypes.STRING,
+    allowNull: true
+  },
+  userId: {
+    type: DataTypes.INTEGER,
+    allowNull: false,
+    references: {
+      model: 'users',
+      key: 'id'
+    }
+  },
+  notes: {
+    type: DataTypes.TEXT,
+    allowNull: true
+  }
+}, {
+  tableName: 'leads',
+  timestamps: true,
+  createdAt: 'created_at',
+  updatedAt: 'updated_at'
+});
+
+Lead.associate = (models) => {
+  Lead.belongsTo(models.Users, {
+    foreignKey: 'userId',
+    as: 'Users'
+  });
+  Lead.hasMany(models.Interaction, {
+    foreignKey: 'leadId',
+    as: 'Interactions',
+    onDelete: 'CASCADE'
+  });
+};
+
+module.exports = Lead;

--- a/backend/routes/crmRoutes.js
+++ b/backend/routes/crmRoutes.js
@@ -1,0 +1,26 @@
+const express = require('express');
+const router = express.Router();
+const crmController = require('../controllers/crmController');
+
+// Customer routes
+router.post('/customers', crmController.createCustomer);
+router.get('/customers', crmController.getCustomers);
+router.get('/customers/:id', crmController.getCustomerById);
+router.put('/customers/:id', crmController.updateCustomer);
+router.delete('/customers/:id', crmController.deleteCustomer);
+
+// Lead routes
+router.post('/leads', crmController.createLead);
+router.get('/leads', crmController.getLeads);
+router.get('/leads/:id', crmController.getLeadById);
+router.put('/leads/:id', crmController.updateLead);
+router.delete('/leads/:id', crmController.deleteLead);
+
+// Interaction routes
+router.post('/interactions', crmController.createInteraction);
+router.get('/interactions', crmController.getInteractions);
+router.get('/interactions/:id', crmController.getInteractionById);
+router.put('/interactions/:id', crmController.updateInteraction);
+router.delete('/interactions/:id', crmController.deleteInteraction);
+
+module.exports = router;


### PR DESCRIPTION
## Summary
- add Customer, Lead, and Interaction models with user associations
- implement crmController with CRUD endpoints
- expose authenticated /crm API routes and mount them in the server

## Testing
- `npm test` (fails: no test specified)
- `npm run test:associations` (fails: unable to connect to database)


------
https://chatgpt.com/codex/tasks/task_e_689ddb83375c832f99f09a02e824789c