### PR TITLE
Add basic CRM pages, components, and service

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -45,6 +45,9 @@ import ListSubscriptions from './pagesSuperAdmin/Subscriptions/ListSubscriptions
 import ListApiKeys from './pagesSuperAdmin/ApiKeys/ListApiKeys';
 import ListQuotes from './pagesSuperAdmin/Quote/ListQuotes';
 import AuthHandler from './authentification/AuthHandler';
+import LeadsPage from './pages/LeadsPage';
+import CustomersPage from './pages/CustomersPage';
+import InteractionFormPage from './pages/InteractionForm';
 
 function App() {
   const { isLoading, user } = useAuth(); 
@@ -109,6 +112,11 @@ function App() {
               <Route path="create" element={<CustomDomainForm />} />
               <Route path="edit/:id" element={<CustomDomainForm />} />
             </Route>
+            <Route path="crm">
+              <Route path="leads" element={<LeadsPage />} />
+              <Route path="customers" element={<CustomersPage />} />
+              <Route path="interactions/:id" element={<InteractionFormPage />} />
+            </Route>
           </Route>
 
           <Route path="/super-admin" element={<Layout role="superAdmin" />}>
@@ -142,6 +150,11 @@ function App() {
             </Route>
             <Route path="custom-domains">
               <Route index element={<ListCustomDomains />} />
+            </Route>
+            <Route path="crm">
+              <Route path="leads" element={<LeadsPage />} />
+              <Route path="customers" element={<CustomersPage />} />
+              <Route path="interactions/:id" element={<InteractionFormPage />} />
             </Route>
             <Route path="subscriptions">
               <Route index element={<ListSubscriptions />} />

--- a/frontend/src/components/CustomerCard.tsx
+++ b/frontend/src/components/CustomerCard.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { Lead, Customer } from '../services/crmService';
+
+interface CustomerCardProps {
+  customer: Lead | Customer;
+  onClick?: () => void;
+}
+
+const CustomerCard: React.FC<CustomerCardProps> = ({ customer, onClick }) => {
+  return (
+    <div
+      className="p-4 bg-white rounded shadow cursor-pointer hover:shadow-lg transition"
+      onClick={onClick}
+    >
+      <h3 className="text-lg font-semibold text-gray-800">
+        {customer.name}
+      </h3>
+      {'email' in customer && customer.email && (
+        <p className="text-sm text-gray-500">{customer.email}</p>
+      )}
+    </div>
+  );
+};
+
+export default CustomerCard;

--- a/frontend/src/components/InteractionForm.tsx
+++ b/frontend/src/components/InteractionForm.tsx
@@ -1,0 +1,47 @@
+import React, { useState } from 'react';
+import { crmService } from '../services/crmService';
+
+interface InteractionFormProps {
+  customerId: string;
+  onSaved?: () => void;
+}
+
+const InteractionForm: React.FC<InteractionFormProps> = ({ customerId, onSaved }) => {
+  const [note, setNote] = useState('');
+  const [loading, setLoading] = useState(false);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setLoading(true);
+    try {
+      await crmService.createInteraction(customerId, { note });
+      setNote('');
+      onSaved?.();
+    } catch (error) {
+      console.error('Failed to save interaction:', error);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4">
+      <textarea
+        value={note}
+        onChange={e => setNote(e.target.value)}
+        className="w-full p-2 border rounded"
+        rows={4}
+        placeholder="Add notes about the interaction..."
+      />
+      <button
+        type="submit"
+        disabled={loading}
+        className="px-4 py-2 bg-blue-600 text-white rounded disabled:opacity-50"
+      >
+        {loading ? 'Saving...' : 'Save Interaction'}
+      </button>
+    </form>
+  );
+};
+
+export default InteractionForm;

--- a/frontend/src/components/PipelineStage.tsx
+++ b/frontend/src/components/PipelineStage.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+
+interface PipelineStageProps {
+  stages: string[];
+  current?: string;
+  onStageClick?: (stage: string) => void;
+}
+
+const PipelineStage: React.FC<PipelineStageProps> = ({ stages, current, onStageClick }) => {
+  return (
+    <div className="flex space-x-2 mb-4">
+      {stages.map(stage => (
+        <button
+          key={stage}
+          onClick={() => onStageClick?.(stage)}
+          className={`px-3 py-1 rounded-full text-sm border transition-colors duration-150 ${
+            current === stage
+              ? 'bg-blue-600 text-white border-blue-600'
+              : 'bg-gray-100 text-gray-700 border-gray-300 hover:bg-gray-200'
+          }`}
+        >
+          {stage}
+        </button>
+      ))}
+    </div>
+  );
+};
+
+export default PipelineStage;

--- a/frontend/src/pages/CustomersPage.tsx
+++ b/frontend/src/pages/CustomersPage.tsx
@@ -1,0 +1,35 @@
+import React, { useEffect, useState } from 'react';
+import { crmService, Customer } from '../services/crmService';
+import CustomerCard from '../components/CustomerCard';
+import { useNavigate, useLocation } from 'react-router-dom';
+
+const CustomersPage: React.FC = () => {
+  const [customers, setCustomers] = useState<Customer[]>([]);
+  const navigate = useNavigate();
+  const location = useLocation();
+  const basePath = location.pathname.startsWith('/super-admin') ? '/super-admin' : '/admin';
+
+  useEffect(() => {
+    crmService
+      .getCustomers()
+      .then(data => setCustomers(data))
+      .catch(err => console.error('Failed to load customers', err));
+  }, []);
+
+  return (
+    <div className="space-y-4 py-6">
+      <h1 className="text-2xl font-semibold">Customers</h1>
+      <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+        {customers.map(customer => (
+          <CustomerCard
+            key={customer.id}
+            customer={customer}
+            onClick={() => navigate(`${basePath}/crm/interactions/${customer.id}`)}
+          />
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default CustomersPage;

--- a/frontend/src/pages/InteractionForm.tsx
+++ b/frontend/src/pages/InteractionForm.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { useParams } from 'react-router-dom';
+import InteractionForm from '../components/InteractionForm';
+
+const InteractionFormPage: React.FC = () => {
+  const { id } = useParams<{ id: string }>();
+
+  if (!id) {
+    return <div>No customer selected</div>;
+  }
+
+  return (
+    <div className="space-y-4 py-6">
+      <h1 className="text-2xl font-semibold">Log Interaction</h1>
+      <InteractionForm customerId={id} />
+    </div>
+  );
+};
+
+export default InteractionFormPage;

--- a/frontend/src/pages/LeadsPage.tsx
+++ b/frontend/src/pages/LeadsPage.tsx
@@ -1,0 +1,44 @@
+import React, { useEffect, useState } from 'react';
+import { crmService, Lead } from '../services/crmService';
+import CustomerCard from '../components/CustomerCard';
+import PipelineStage from '../components/PipelineStage';
+import { useNavigate, useLocation } from 'react-router-dom';
+
+const LeadsPage: React.FC = () => {
+  const [leads, setLeads] = useState<Lead[]>([]);
+  const [stageFilter, setStageFilter] = useState<string>();
+  const navigate = useNavigate();
+  const location = useLocation();
+  const basePath = location.pathname.startsWith('/super-admin') ? '/super-admin' : '/admin';
+
+  useEffect(() => {
+    crmService
+      .getLeads()
+      .then(data => setLeads(data))
+      .catch(err => console.error('Failed to load leads', err));
+  }, []);
+
+  const stages = ['New', 'Contacted', 'Qualified', 'Lost', 'Won'];
+
+  const filteredLeads = stageFilter
+    ? leads.filter(l => l.stage === stageFilter)
+    : leads;
+
+  return (
+    <div className="space-y-4 py-6">
+      <h1 className="text-2xl font-semibold">Leads</h1>
+      <PipelineStage stages={stages} current={stageFilter} onStageClick={setStageFilter} />
+      <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+        {filteredLeads.map(lead => (
+          <CustomerCard
+            key={lead.id}
+            customer={lead}
+            onClick={() => navigate(`${basePath}/crm/interactions/${lead.id}`)}
+          />
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default LeadsPage;

--- a/frontend/src/services/crmService.ts
+++ b/frontend/src/services/crmService.ts
@@ -1,0 +1,46 @@
+import axios from 'axios';
+import { getToken } from './tokenService';
+
+const api = axios.create({
+  baseURL: `${import.meta.env.VITE_API_BASE_URL || 'http://localhost:3000'}/crm`,
+  timeout: Number(import.meta.env.VITE_API_TIMEOUT) || 30000,
+});
+
+api.interceptors.request.use(config => {
+  const token = getToken();
+  if (token) {
+    config.headers.Authorization = `Bearer ${token}`;
+  }
+  return config;
+});
+
+export interface Lead {
+  id: string;
+  name: string;
+  email?: string;
+  stage?: string;
+}
+
+export interface Customer {
+  id: string;
+  name: string;
+  email?: string;
+}
+
+export interface Interaction {
+  id: string;
+  customerId: string;
+  note: string;
+  createdAt?: string;
+}
+
+export const crmService = {
+  getLeads: () => api.get<Lead[]>('/leads').then(res => res.data),
+  getCustomers: () => api.get<Customer[]>('/customers').then(res => res.data),
+  getInteractions: (customerId: string) =>
+    api.get<Interaction[]>(`/customers/${customerId}/interactions`).then(res => res.data),
+  createInteraction: (customerId: string, data: { note: string }) =>
+    api.post(`/customers/${customerId}/interactions`, data).then(res => res.data),
+};
+
+export default crmService;

--- a/frontend/src/templateBack/SideBar.tsx
+++ b/frontend/src/templateBack/SideBar.tsx
@@ -54,6 +54,7 @@ const Sidebar: React.FC<SidebarProps> = ({
   };
 
   const menuItems = useMemo(() => {
+    
     const commonItems = [
       {
         path: `${basePath}/dashboard`,
@@ -109,6 +110,24 @@ const Sidebar: React.FC<SidebarProps> = ({
           </svg>
         ),
         label: 'Custom Domains'
+      },
+      {
+        path: `${basePath}/crm/leads`,
+        icon: (
+          <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z" />
+          </svg>
+        ),
+        label: 'Leads'
+      },
+      {
+        path: `${basePath}/crm/customers`,
+        icon: (
+          <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0z" />
+          </svg>
+        ),
+        label: 'Customers'
       }
     ];
 


### PR DESCRIPTION
## Summary
- Add Axios-based CRM service to interact with `/crm` API endpoints.
- Create reusable components for customer cards, pipeline stages, and interaction form.
- Introduce Leads, Customers, and Interaction pages with navigation and routing.

## Testing
- `npm run lint` *(fails: Unexpected any, unused vars, etc. in existing files)*

------
https://chatgpt.com/codex/tasks/task_e_689de05e17f8832f833498caf994d27e