### PR TITLE
Enhance CRM pages with tables and interactions

### DIFF
--- a/frontend/src/pages/CustomersPage.tsx
+++ b/frontend/src/pages/CustomersPage.tsx
@@ -1,6 +1,5 @@
 import React, { useEffect, useState } from 'react';
 import { crmService, Customer } from '../services/crmService';
-import CustomerCard from '../components/CustomerCard';
 import { useNavigate, useLocation } from 'react-router-dom';
 
 const CustomersPage: React.FC = () => {
@@ -74,16 +73,44 @@ const CustomersPage: React.FC = () => {
           Add Customer
         </button>
       </form>
-      <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
-        {customers.map(customer => (
-          <CustomerCard
-            key={customer.id}
-            customer={customer}
-            onClick={() => navigate(`${basePath}/crm/interactions/${customer.id}`)}
-            onEdit={() => handleEdit(customer)}
-            onDelete={() => handleDelete(customer.id)}
-          />
-        ))}
+      <div className="overflow-x-auto">
+        <table className="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
+          <thead className="bg-gray-50 dark:bg-gray-700">
+            <tr>
+              <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Name</th>
+              <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Email</th>
+              <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Actions</th>
+            </tr>
+          </thead>
+          <tbody className="bg-white dark:bg-gray-800 divide-y divide-gray-200 dark:divide-gray-700">
+            {customers.map(customer => (
+              <tr key={customer.id} className="hover:bg-gray-50 dark:hover:bg-gray-700">
+                <td className="px-4 py-4 whitespace-nowrap text-sm text-gray-900 dark:text-gray-200">{customer.name}</td>
+                <td className="px-4 py-4 whitespace-nowrap text-sm text-gray-500 dark:text-gray-400">{customer.email}</td>
+                <td className="px-4 py-4 whitespace-nowrap text-sm space-x-2">
+                  <button
+                    className="text-blue-600"
+                    onClick={() => navigate(`${basePath}/crm/interactions/${customer.id}`)}
+                  >
+                    Interactions
+                  </button>
+                  <button
+                    className="text-green-600"
+                    onClick={() => handleEdit(customer)}
+                  >
+                    Edit
+                  </button>
+                  <button
+                    className="text-red-600"
+                    onClick={() => handleDelete(customer.id)}
+                  >
+                    Delete
+                  </button>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
       </div>
     </div>
   );

--- a/frontend/src/pages/InteractionForm.tsx
+++ b/frontend/src/pages/InteractionForm.tsx
@@ -1,9 +1,43 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { useParams } from 'react-router-dom';
 import InteractionForm from '../components/InteractionForm';
+import { crmService, Interaction } from '../services/crmService';
 
-const InteractionFormPage: React.FC = () => {
+const InteractionsPage: React.FC = () => {
   const { id } = useParams<{ id: string }>();
+  const [interactions, setInteractions] = useState<Interaction[]>([]);
+
+  const loadInteractions = () => {
+    if (!id) return;
+    crmService
+      .getInteractions(id)
+      .then(data => setInteractions(data))
+      .catch(err => console.error('Failed to load interactions', err));
+  };
+
+  useEffect(() => {
+    loadInteractions();
+  }, [id]);
+
+  const handleEdit = async (interaction: Interaction) => {
+    const note = prompt('Note', interaction.notes);
+    if (!note) return;
+    try {
+      const updated = await crmService.updateInteraction(interaction.id, { note });
+      setInteractions(interactions.map(i => (i.id === interaction.id ? updated : i)));
+    } catch (error) {
+      console.error('Failed to update interaction', error);
+    }
+  };
+
+  const handleDelete = async (interactionId: string) => {
+    try {
+      await crmService.deleteInteraction(interactionId);
+      setInteractions(interactions.filter(i => i.id !== interactionId));
+    } catch (error) {
+      console.error('Failed to delete interaction', error);
+    }
+  };
 
   if (!id) {
     return <div>No customer selected</div>;
@@ -11,10 +45,45 @@ const InteractionFormPage: React.FC = () => {
 
   return (
     <div className="space-y-4 py-6">
-      <h1 className="text-2xl font-semibold">Log Interaction</h1>
-      <InteractionForm customerId={id} />
+      <h1 className="text-2xl font-semibold">Interactions</h1>
+      <InteractionForm customerId={id} onSaved={loadInteractions} />
+      <div className="overflow-x-auto">
+        <table className="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
+          <thead className="bg-gray-50 dark:bg-gray-700">
+            <tr>
+              <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Note</th>
+              <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Created</th>
+              <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Actions</th>
+            </tr>
+          </thead>
+          <tbody className="bg-white dark:bg-gray-800 divide-y divide-gray-200 dark:divide-gray-700">
+            {interactions.map(interaction => (
+              <tr key={interaction.id} className="hover:bg-gray-50 dark:hover:bg-gray-700">
+                <td className="px-4 py-4 whitespace-nowrap text-sm text-gray-900 dark:text-gray-200">{interaction.notes}</td>
+                <td className="px-4 py-4 whitespace-nowrap text-sm text-gray-500 dark:text-gray-400">
+                  {interaction.createdAt ? new Date(interaction.createdAt).toLocaleString() : ''}
+                </td>
+                <td className="px-4 py-4 whitespace-nowrap text-sm space-x-2">
+                  <button
+                    className="text-green-600"
+                    onClick={() => handleEdit(interaction)}
+                  >
+                    Edit
+                  </button>
+                  <button
+                    className="text-red-600"
+                    onClick={() => handleDelete(interaction.id)}
+                  >
+                    Delete
+                  </button>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
     </div>
   );
 };
 
-export default InteractionFormPage;
+export default InteractionsPage;

--- a/frontend/src/pages/LeadsPage.tsx
+++ b/frontend/src/pages/LeadsPage.tsx
@@ -1,6 +1,5 @@
 import React, { useEffect, useState } from 'react';
 import { crmService, Lead } from '../services/crmService';
-import CustomerCard from '../components/CustomerCard';
 import PipelineStage from '../components/PipelineStage';
 import { useNavigate, useLocation } from 'react-router-dom';
 
@@ -83,16 +82,46 @@ const LeadsPage: React.FC = () => {
         </button>
       </form>
       <PipelineStage stages={stages} current={stageFilter} onStageClick={setStageFilter} />
-      <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
-        {filteredLeads.map(lead => (
-          <CustomerCard
-            key={lead.id}
-            customer={lead}
-            onClick={() => navigate(`${basePath}/crm/interactions/${lead.id}`)}
-            onEdit={() => handleEdit(lead)}
-            onDelete={() => handleDelete(lead.id)}
-          />
-        ))}
+      <div className="overflow-x-auto">
+        <table className="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
+          <thead className="bg-gray-50 dark:bg-gray-700">
+            <tr>
+              <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Name</th>
+              <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Email</th>
+              <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Status</th>
+              <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Actions</th>
+            </tr>
+          </thead>
+          <tbody className="bg-white dark:bg-gray-800 divide-y divide-gray-200 dark:divide-gray-700">
+            {filteredLeads.map(lead => (
+              <tr key={lead.id} className="hover:bg-gray-50 dark:hover:bg-gray-700">
+                <td className="px-4 py-4 whitespace-nowrap text-sm text-gray-900 dark:text-gray-200">{lead.name}</td>
+                <td className="px-4 py-4 whitespace-nowrap text-sm text-gray-500 dark:text-gray-400">{lead.email}</td>
+                <td className="px-4 py-4 whitespace-nowrap text-sm text-gray-500 dark:text-gray-400">{lead.status}</td>
+                <td className="px-4 py-4 whitespace-nowrap text-sm space-x-2">
+                  <button
+                    className="text-blue-600"
+                    onClick={() => navigate(`${basePath}/crm/interactions/${lead.id}`)}
+                  >
+                    Interactions
+                  </button>
+                  <button
+                    className="text-green-600"
+                    onClick={() => handleEdit(lead)}
+                  >
+                    Edit
+                  </button>
+                  <button
+                    className="text-red-600"
+                    onClick={() => handleDelete(lead.id)}
+                  >
+                    Delete
+                  </button>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
       </div>
     </div>
   );

--- a/frontend/src/services/crmService.ts
+++ b/frontend/src/services/crmService.ts
@@ -54,6 +54,9 @@ export const crmService = {
     api.get<Interaction[]>(`/customers/${customerId}/interactions`).then(res => res.data),
   createInteraction: (customerId: string, data: { note: string }) =>
     api.post(`/customers/${customerId}/interactions`, { notes: data.note }).then(res => res.data),
+  updateInteraction: (id: string, data: { note: string }) =>
+    api.put(`/interactions/${id}`, { notes: data.note }).then(res => res.data),
+  deleteInteraction: (id: string) => api.delete(`/interactions/${id}`),
 };
 
 export default crmService;

--- a/frontend/src/templateBack/SideBar.tsx
+++ b/frontend/src/templateBack/SideBar.tsx
@@ -112,6 +112,10 @@ const Sidebar: React.FC<SidebarProps> = ({
         label: 'Custom Domains'
       },
       {
+        type: 'section',
+        label: 'CRM'
+      },
+      {
         path: `${basePath}/crm/leads`,
         icon: (
           <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -185,18 +189,25 @@ const Sidebar: React.FC<SidebarProps> = ({
     return commonItems;
   }, [role, basePath]);
 
-  const renderMenuItem = (item: typeof menuItems[0]) => {
+  const renderMenuItem = (item: any) => {
+    if (item.type === 'section') {
+      return (
+        <li key={item.label} className="px-6 py-2 text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase">
+          {item.label}
+        </li>
+      );
+    }
     const active = isActive(item.path, item.exact);
-    
+
     return (
       <li key={item.path} className="relative px-6 py-3">
         {active && (
-          <span 
+          <span
             className="absolute inset-y-0 left-0 w-1 rounded-tr-lg rounded-br-lg bg-blue-50"
             aria-hidden="true"
           />
         )}
-        
+
         <Link
           to={item.path}
           onClick={handleMobileLinkClick}


### PR DESCRIPTION
## Summary
- Add update/delete for CRM interactions and expose through service
- Replace CRM lead and customer grids with table-based layouts
- Implement interactions page with table and edit/delete actions
- Group CRM section in sidebar navigation

## Testing
- `npm test` (backend) *(fails: jest: not found)*
- `npm test` (frontend) *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b44ce176bc832fa4eaa1ba1d719979