### PR TITLE
feat(crm): support lead interactions and improve sidebar

### DIFF
--- a/backend/controllers/crmController.js
+++ b/backend/controllers/crmController.js
@@ -163,6 +163,30 @@ const createInteractionForCustomer = async (req, res) => {
   }
 };
 
+const getInteractionsByLead = async (req, res) => {
+  try {
+    const interactions = await Interaction.findAll({
+      where: { leadId: req.params.id, userId: req.user.id },
+    });
+    res.json(interactions);
+  } catch (error) {
+    res.status(500).json({ error: 'Server error', details: error.message });
+  }
+};
+
+const createInteractionForLead = async (req, res) => {
+  try {
+    const interaction = await Interaction.create({
+      ...req.body,
+      leadId: req.params.id,
+      userId: req.user.id,
+    });
+    res.status(201).json(interaction);
+  } catch (error) {
+    res.status(500).json({ error: 'Server error', details: error.message });
+  }
+};
+
 const createInteraction = async (req, res) => {
   try {
     const interaction = await Interaction.create({
@@ -243,6 +267,8 @@ module.exports = {
   deleteLead,
   getInteractionsByCustomer,
   createInteractionForCustomer,
+  getInteractionsByLead,
+  createInteractionForLead,
   createInteraction,
   getInteractions,
   getInteractionById,

--- a/backend/routes/crmRoutes.js
+++ b/backend/routes/crmRoutes.js
@@ -17,6 +17,8 @@ router.get('/leads', crmController.getLeads);
 router.get('/leads/:id', crmController.getLeadById);
 router.put('/leads/:id', crmController.updateLead);
 router.delete('/leads/:id', crmController.deleteLead);
+router.get('/leads/:id/interactions', crmController.getInteractionsByLead);
+router.post('/leads/:id/interactions', crmController.createInteractionForLead);
 
 // Interaction routes
 router.post('/interactions', crmController.createInteraction);

--- a/frontend/src/templateBack/SideBar.tsx
+++ b/frontend/src/templateBack/SideBar.tsx
@@ -54,8 +54,9 @@ const Sidebar: React.FC<SidebarProps> = ({
   };
 
   const menuItems = useMemo(() => {
-    
+
     const commonItems = [
+      { type: 'section', label: 'Main' },
       {
         path: `${basePath}/dashboard`,
         icon: (
@@ -138,6 +139,7 @@ const Sidebar: React.FC<SidebarProps> = ({
     if (role === 'superAdmin') {
       return [
         ...commonItems,
+        { type: 'section', label: 'Administration' },
         {
           path: `${basePath}/users`,
           icon: (


### PR DESCRIPTION
## Summary
- add controller and routes to manage lead interactions
- organize sidebar into Main, CRM, and Administration sections

## Testing
- `npm run lint` (fails: 143 problems)
- `npm test` (fails: jest not found)
- `npm install` (fails: 403 Forbidden when fetching jest)


------
https://chatgpt.com/codex/tasks/task_e_68b451016648832f8f5fc93971470d9a