### PR TITLE
feat: add search and sort for leads

### DIFF
--- a/backend/controllers/crmController.js
+++ b/backend/controllers/crmController.js
@@ -102,8 +102,24 @@ const createLead = async (req, res) => {
 
 const getLeads = async (req, res) => {
   try {
+    const { search, sortBy = 'created_at', order = 'ASC' } = req.query;
+
+    const where = { userId: req.user.id };
+    if (search) {
+      where[Op.or] = [
+        { name: { [Op.like]: `%${search}%` } },
+        { email: { [Op.like]: `%${search}%` } },
+        { phone: { [Op.like]: `%${search}%` } },
+      ];
+    }
+
+    const allowedSortFields = ['name', 'email', 'created_at'];
+    const sortField = allowedSortFields.includes(sortBy) ? sortBy : 'created_at';
+    const sortOrder = order.toUpperCase() === 'DESC' ? 'DESC' : 'ASC';
+
     const leads = await Lead.findAll({
-      where: { userId: req.user.id },
+      where,
+      order: [[sortField, sortOrder]],
     });
     res.json(leads);
   } catch (error) {

--- a/frontend/src/pages/LeadsPage.tsx
+++ b/frontend/src/pages/LeadsPage.tsx
@@ -9,16 +9,19 @@ const LeadsPage: React.FC = () => {
   const [form, setForm] = useState({ name: '', email: '', phone: '', status: 'New', notes: '' });
   const [editingLead, setEditingLead] = useState<Lead | null>(null);
   const [editForm, setEditForm] = useState({ name: '', email: '', phone: '', status: '', notes: '' });
+  const [search, setSearch] = useState('');
+  const [sortBy, setSortBy] = useState('name');
+  const [order, setOrder] = useState<'asc' | 'desc'>('asc');
   const navigate = useNavigate();
   const location = useLocation();
   const basePath = location.pathname.startsWith('/super-admin') ? '/super-admin' : '/admin';
 
   useEffect(() => {
     crmService
-      .getLeads()
+      .getLeads({ search, sortBy, order })
       .then(data => setLeads(data))
       .catch(err => console.error('Failed to load leads', err));
-  }, []);
+  }, [search, sortBy, order]);
 
   const stages = ['New', 'Contacted', 'Qualified', 'Lost', 'Won'];
 
@@ -32,6 +35,10 @@ const LeadsPage: React.FC = () => {
 
   const handleEditChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>) => {
     setEditForm({ ...editForm, [e.target.name]: e.target.value });
+  };
+
+  const handleSearchChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setSearch(e.target.value);
   };
 
   const handleSubmit = async (e: React.FormEvent) => {
@@ -80,6 +87,31 @@ const LeadsPage: React.FC = () => {
   return (
     <div className="space-y-4 py-6">
       <h1 className="text-2xl font-semibold">Leads</h1>
+      <div className="flex flex-col sm:flex-row gap-2 sm:items-center">
+        <input
+          value={search}
+          onChange={handleSearchChange}
+          placeholder="Search leads"
+          className="p-2 border rounded w-full sm:w-64"
+        />
+        <select
+          value={sortBy}
+          onChange={e => setSortBy(e.target.value)}
+          className="p-2 border rounded"
+        >
+          <option value="name">Name</option>
+          <option value="email">Email</option>
+          <option value="created_at">Created</option>
+        </select>
+        <select
+          value={order}
+          onChange={e => setOrder(e.target.value as 'asc' | 'desc')}
+          className="p-2 border rounded"
+        >
+          <option value="asc">Asc</option>
+          <option value="desc">Desc</option>
+        </select>
+      </div>
       <form onSubmit={handleSubmit} className="space-y-2 max-w-sm">
         <input
           name="name"

--- a/frontend/src/services/crmService.ts
+++ b/frontend/src/services/crmService.ts
@@ -43,7 +43,8 @@ export interface Interaction {
 }
 
 export const crmService = {
-  getLeads: () => api.get<Lead[]>('/leads').then(res => res.data),
+  getLeads: (params?: { search?: string; sortBy?: string; order?: 'asc' | 'desc' }) =>
+    api.get<Lead[]>('/leads', { params }).then(res => res.data),
   createLead: (data: Partial<Lead>) => api.post('/leads', data).then(res => res.data),
   updateLead: (id: string, data: Partial<Lead>) => api.put(`/leads/${id}`, data).then(res => res.data),
   deleteLead: (id: string) => api.delete(`/leads/${id}`),


### PR DESCRIPTION
## Summary
- support search and sorting for CRM leads API
- allow passing search and sort params from frontend service
- add search/sort inputs to leads page

## Testing
- `npm test` *(fails: jest: not found)*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/jest)*
- `npm run lint` *(fails: 125 errors, 18 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68b461aead7c832fa24d3cd7099722a9