### PR TITLE
feat: add tag management

### DIFF
--- a/backend/models/Customer.js
+++ b/backend/models/Customer.js
@@ -53,6 +53,11 @@ Customer.associate = (models) => {
     as: 'Interactions',
     onDelete: 'CASCADE'
   });
+  Customer.belongsToMany(models.Tag, {
+    through: models.CustomerTag,
+    foreignKey: 'customerId',
+    as: 'Tags'
+  });
 };
 
 module.exports = Customer;

--- a/backend/models/CustomerTag.js
+++ b/backend/models/CustomerTag.js
@@ -1,0 +1,26 @@
+const { DataTypes } = require('sequelize');
+const sequelize = require('../database/sequelize');
+
+const CustomerTag = sequelize.define('CustomerTag', {
+  customerId: {
+    type: DataTypes.INTEGER,
+    references: {
+      model: 'customers',
+      key: 'id',
+    },
+    onDelete: 'CASCADE',
+  },
+  tagId: {
+    type: DataTypes.INTEGER,
+    references: {
+      model: 'tags',
+      key: 'id',
+    },
+    onDelete: 'CASCADE',
+  },
+}, {
+  tableName: 'customer_tags',
+  timestamps: false,
+});
+
+module.exports = CustomerTag;

--- a/backend/models/Lead.js
+++ b/backend/models/Lead.js
@@ -52,6 +52,11 @@ Lead.associate = (models) => {
     as: 'Interactions',
     onDelete: 'CASCADE'
   });
+  Lead.belongsToMany(models.Tag, {
+    through: models.LeadTag,
+    foreignKey: 'leadId',
+    as: 'Tags'
+  });
 };
 
 module.exports = Lead;

--- a/backend/models/LeadTag.js
+++ b/backend/models/LeadTag.js
@@ -1,0 +1,26 @@
+const { DataTypes } = require('sequelize');
+const sequelize = require('../database/sequelize');
+
+const LeadTag = sequelize.define('LeadTag', {
+  leadId: {
+    type: DataTypes.INTEGER,
+    references: {
+      model: 'leads',
+      key: 'id',
+    },
+    onDelete: 'CASCADE',
+  },
+  tagId: {
+    type: DataTypes.INTEGER,
+    references: {
+      model: 'tags',
+      key: 'id',
+    },
+    onDelete: 'CASCADE',
+  },
+}, {
+  tableName: 'lead_tags',
+  timestamps: false,
+});
+
+module.exports = LeadTag;

--- a/backend/models/Tag.js
+++ b/backend/models/Tag.js
@@ -1,0 +1,47 @@
+const { DataTypes } = require('sequelize');
+const sequelize = require('../database/sequelize');
+
+const Tag = sequelize.define('Tag', {
+  id: {
+    type: DataTypes.INTEGER,
+    primaryKey: true,
+    autoIncrement: true,
+  },
+  name: {
+    type: DataTypes.STRING,
+    allowNull: false,
+  },
+  userId: {
+    type: DataTypes.INTEGER,
+    allowNull: false,
+    references: {
+      model: 'users',
+      key: 'id',
+    },
+    onDelete: 'CASCADE',
+  },
+}, {
+  tableName: 'tags',
+  timestamps: true,
+  createdAt: 'created_at',
+  updatedAt: 'updated_at',
+});
+
+Tag.associate = (models) => {
+  Tag.belongsTo(models.Users, {
+    foreignKey: 'userId',
+    as: 'Users',
+  });
+  Tag.belongsToMany(models.Customer, {
+    through: models.CustomerTag,
+    foreignKey: 'tagId',
+    as: 'Customers',
+  });
+  Tag.belongsToMany(models.Lead, {
+    through: models.LeadTag,
+    foreignKey: 'tagId',
+    as: 'Leads',
+  });
+};
+
+module.exports = Tag;

--- a/backend/routes/crmRoutes.js
+++ b/backend/routes/crmRoutes.js
@@ -11,6 +11,8 @@ router.put('/customers/:id', requireAuth, crmController.updateCustomer);
 router.delete('/customers/:id', requireAuth, crmController.deleteCustomer);
 router.get('/customers/:id/interactions', requireAuth, crmController.getInteractionsByCustomer);
 router.post('/customers/:id/interactions', requireAuth, crmController.createInteractionForCustomer);
+router.post('/customers/:id/tags/:tagId', requireAuth, crmController.assignTagToCustomer);
+router.delete('/customers/:id/tags/:tagId', requireAuth, crmController.unassignTagFromCustomer);
 
 // Lead routes
 router.post('/leads', requireAuth, crmController.createLead);
@@ -20,6 +22,14 @@ router.put('/leads/:id', requireAuth, crmController.updateLead);
 router.delete('/leads/:id', requireAuth, crmController.deleteLead);
 router.get('/leads/:id/interactions', requireAuth, crmController.getInteractionsByLead);
 router.post('/leads/:id/interactions', requireAuth, crmController.createInteractionForLead);
+router.post('/leads/:id/tags/:tagId', requireAuth, crmController.assignTagToLead);
+router.delete('/leads/:id/tags/:tagId', requireAuth, crmController.unassignTagFromLead);
+
+// Tag routes
+router.post('/tags', requireAuth, crmController.createTag);
+router.get('/tags', requireAuth, crmController.getTags);
+router.put('/tags/:id', requireAuth, crmController.updateTag);
+router.delete('/tags/:id', requireAuth, crmController.deleteTag);
 
 // Interaction routes
 router.post('/interactions', requireAuth, crmController.createInteraction);

--- a/frontend/src/pages/LeadsPage.tsx
+++ b/frontend/src/pages/LeadsPage.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { crmService, Lead } from '../services/crmService';
+import { crmService, Lead, Tag } from '../services/crmService';
 import PipelineStage from '../components/PipelineStage';
 import { useNavigate, useLocation } from 'react-router-dom';
 
@@ -7,21 +7,33 @@ const LeadsPage: React.FC = () => {
   const [leads, setLeads] = useState<Lead[]>([]);
   const [stageFilter, setStageFilter] = useState<string>();
   const [form, setForm] = useState({ name: '', email: '', phone: '', status: 'New', notes: '' });
+  const [formTags, setFormTags] = useState<string[]>([]);
   const [editingLead, setEditingLead] = useState<Lead | null>(null);
   const [editForm, setEditForm] = useState({ name: '', email: '', phone: '', status: '', notes: '' });
+  const [editFormTags, setEditFormTags] = useState<string[]>([]);
   const [search, setSearch] = useState('');
   const [sortBy, setSortBy] = useState('name');
   const [order, setOrder] = useState<'asc' | 'desc'>('asc');
+  const [tags, setTags] = useState<Tag[]>([]);
+  const [newTag, setNewTag] = useState('');
+  const [filterTags, setFilterTags] = useState<string[]>([]);
   const navigate = useNavigate();
   const location = useLocation();
   const basePath = location.pathname.startsWith('/super-admin') ? '/super-admin' : '/admin';
 
   useEffect(() => {
     crmService
-      .getLeads({ search, sortBy, order })
+      .getTags()
+      .then(setTags)
+      .catch(err => console.error('Failed to load tags', err));
+  }, []);
+
+  useEffect(() => {
+    crmService
+      .getLeads({ search, sortBy, order, tags: filterTags })
       .then(data => setLeads(data))
       .catch(err => console.error('Failed to load leads', err));
-  }, [search, sortBy, order]);
+  }, [search, sortBy, order, filterTags]);
 
   const stages = ['New', 'Contacted', 'Qualified', 'Lost', 'Won'];
 
@@ -41,12 +53,40 @@ const LeadsPage: React.FC = () => {
     setSearch(e.target.value);
   };
 
+  const handleFormTagsChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    setFormTags(Array.from(e.target.selectedOptions, option => option.value));
+  };
+
+  const handleEditTagsChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    setEditFormTags(Array.from(e.target.selectedOptions, option => option.value));
+  };
+
+  const handleFilterTagsChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    setFilterTags(Array.from(e.target.selectedOptions, option => option.value));
+  };
+
+  const handleCreateTag = async () => {
+    if (!newTag.trim()) return;
+    try {
+      const created = await crmService.createTag({ name: newTag.trim() });
+      setTags([...tags, created]);
+      setNewTag('');
+    } catch (error) {
+      console.error('Failed to create tag', error);
+    }
+  };
+
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     try {
       const newLead = await crmService.createLead(form);
-      setLeads([...leads, newLead]);
+      for (const tagId of formTags) {
+        await crmService.assignTagToLead(newLead.id, tagId);
+      }
+      const refreshed = await crmService.getLeads({ search, sortBy, order, tags: filterTags });
+      setLeads(refreshed);
       setForm({ name: '', email: '', phone: '', status: 'New', notes: '' });
+      setFormTags([]);
     } catch (error) {
       console.error('Failed to create lead', error);
     }
@@ -70,14 +110,25 @@ const LeadsPage: React.FC = () => {
       status: lead.status || 'New',
       notes: lead.notes || '',
     });
+    setEditFormTags(lead.Tags?.map(t => t.id.toString()) || []);
   };
 
   const handleEditSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     if (!editingLead) return;
     try {
-      const updated = await crmService.updateLead(editingLead.id, editForm);
-      setLeads(leads.map(l => (l.id === editingLead.id ? updated : l)));
+      await crmService.updateLead(editingLead.id, editForm);
+      const prev = editingLead.Tags?.map(t => t.id.toString()) || [];
+      const toAdd = editFormTags.filter(id => !prev.includes(id));
+      const toRemove = prev.filter(id => !editFormTags.includes(id));
+      for (const id of toAdd) {
+        await crmService.assignTagToLead(editingLead.id, id);
+      }
+      for (const id of toRemove) {
+        await crmService.unassignTagFromLead(editingLead.id, id);
+      }
+      const refreshed = await crmService.getLeads({ search, sortBy, order, tags: filterTags });
+      setLeads(refreshed);
       setEditingLead(null);
     } catch (error) {
       console.error('Failed to update lead', error);
@@ -111,6 +162,33 @@ const LeadsPage: React.FC = () => {
           <option value="asc">Asc</option>
           <option value="desc">Desc</option>
         </select>
+        <select
+          multiple
+          value={filterTags}
+          onChange={handleFilterTagsChange}
+          className="p-2 border rounded"
+        >
+          {tags.map(tag => (
+            <option key={tag.id} value={tag.id}>
+              {tag.name}
+            </option>
+          ))}
+        </select>
+      </div>
+      <div className="flex gap-2">
+        <input
+          value={newTag}
+          onChange={e => setNewTag(e.target.value)}
+          placeholder="New tag"
+          className="p-2 border rounded"
+        />
+        <button
+          type="button"
+          onClick={handleCreateTag}
+          className="px-4 py-2 bg-blue-600 text-white rounded"
+        >
+          Add Tag
+        </button>
       </div>
       <form onSubmit={handleSubmit} className="space-y-2 max-w-sm">
         <input
@@ -143,6 +221,18 @@ const LeadsPage: React.FC = () => {
           {stages.map(stage => (
             <option key={stage} value={stage}>
               {stage}
+            </option>
+          ))}
+        </select>
+        <select
+          multiple
+          value={formTags}
+          onChange={handleFormTagsChange}
+          className="w-full p-2 border rounded"
+        >
+          {tags.map(tag => (
+            <option key={tag.id} value={tag.id}>
+              {tag.name}
             </option>
           ))}
         </select>
@@ -194,6 +284,18 @@ const LeadsPage: React.FC = () => {
               </option>
             ))}
           </select>
+          <select
+            multiple
+            value={editFormTags}
+            onChange={handleEditTagsChange}
+            className="w-full p-2 border rounded"
+          >
+            {tags.map(tag => (
+              <option key={tag.id} value={tag.id}>
+                {tag.name}
+              </option>
+            ))}
+          </select>
           <textarea
             name="notes"
             value={editForm.notes}
@@ -215,6 +317,7 @@ const LeadsPage: React.FC = () => {
               <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Email</th>
               <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Phone</th>
               <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Status</th>
+              <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Tags</th>
               <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Actions</th>
             </tr>
           </thead>
@@ -225,6 +328,9 @@ const LeadsPage: React.FC = () => {
                 <td className="px-4 py-4 whitespace-nowrap text-sm text-gray-500 dark:text-gray-400">{lead.email}</td>
                 <td className="px-4 py-4 whitespace-nowrap text-sm text-gray-500 dark:text-gray-400">{lead.phone}</td>
                 <td className="px-4 py-4 whitespace-nowrap text-sm text-gray-500 dark:text-gray-400">{lead.status}</td>
+                <td className="px-4 py-4 whitespace-nowrap text-sm text-gray-500 dark:text-gray-400">
+                  {lead.Tags?.map(t => t.name).join(', ')}
+                </td>
                 <td className="px-4 py-4 whitespace-nowrap text-sm space-x-2">
                   <button
                     className="text-blue-600"

--- a/frontend/src/services/crmService.ts
+++ b/frontend/src/services/crmService.ts
@@ -14,6 +14,11 @@ api.interceptors.request.use(config => {
   return config;
 });
 
+export interface Tag {
+  id: string;
+  name: string;
+}
+
 export interface Lead {
   id: string;
   name: string;
@@ -21,6 +26,7 @@ export interface Lead {
   phone?: string;
   status?: string;
   notes?: string;
+  Tags?: Tag[];
 }
 
 export interface Customer {
@@ -30,6 +36,7 @@ export interface Customer {
   phone?: string;
   status?: string;
   notes?: string;
+  Tags?: Tag[];
 }
 
 export interface Interaction {
@@ -43,8 +50,17 @@ export interface Interaction {
 }
 
 export const crmService = {
-  getLeads: (params?: { search?: string; sortBy?: string; order?: 'asc' | 'desc' }) =>
-    api.get<Lead[]>('/leads', { params }).then(res => res.data),
+  getLeads: (params?: {
+    search?: string;
+    sortBy?: string;
+    order?: 'asc' | 'desc';
+    tags?: string[];
+  }) =>
+    api
+      .get<Lead[]>('/leads', {
+        params: { ...params, tags: params?.tags?.join(',') },
+      })
+      .then(res => res.data),
   createLead: (data: Partial<Lead>) => api.post('/leads', data).then(res => res.data),
   updateLead: (id: string, data: Partial<Lead>) => api.put(`/leads/${id}`, data).then(res => res.data),
   deleteLead: (id: string) => api.delete(`/leads/${id}`),
@@ -53,11 +69,31 @@ export const crmService = {
     search?: string;
     sortBy?: string;
     order?: 'asc' | 'desc';
-  }) => api.get<Customer[]>('/customers', { params }).then(res => res.data),
+    tags?: string[];
+  }) =>
+    api
+      .get<Customer[]>('/customers', {
+        params: { ...params, tags: params?.tags?.join(',') },
+      })
+      .then(res => res.data),
   createCustomer: (data: Partial<Customer>) => api.post('/customers', data).then(res => res.data),
   updateCustomer: (id: string, data: Partial<Customer>) =>
     api.put(`/customers/${id}`, data).then(res => res.data),
   deleteCustomer: (id: string) => api.delete(`/customers/${id}`),
+
+  createTag: (data: { name: string }) => api.post<Tag>('/tags', data).then(res => res.data),
+  getTags: () => api.get<Tag[]>('/tags').then(res => res.data),
+  updateTag: (id: string, data: { name: string }) =>
+    api.put<Tag>(`/tags/${id}`, data).then(res => res.data),
+  deleteTag: (id: string) => api.delete(`/tags/${id}`),
+  assignTagToCustomer: (customerId: string, tagId: string) =>
+    api.post(`/customers/${customerId}/tags/${tagId}`),
+  unassignTagFromCustomer: (customerId: string, tagId: string) =>
+    api.delete(`/customers/${customerId}/tags/${tagId}`),
+  assignTagToLead: (leadId: string, tagId: string) =>
+    api.post(`/leads/${leadId}/tags/${tagId}`),
+  unassignTagFromLead: (leadId: string, tagId: string) =>
+    api.delete(`/leads/${leadId}/tags/${tagId}`),
 
   getInteractions: (
     entity: 'customers' | 'leads',


### PR DESCRIPTION
## Summary
- add tag entity with join tables for customers and leads
- support tag CRUD, assignment, and tag-based filtering through CRM API
- surface tag management and filtering in customer and lead pages

## Testing
- `npm test` *(fails: jest: not found)*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/jest)*
- `npm test` *(frontend, fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b463b1a500832f96d09a96cb71f5d5