### PR TITLE
Add tasks table to CRM SQL schema

### DIFF
--- a/backend/controllers/taskController.js
+++ b/backend/controllers/taskController.js
@@ -1,0 +1,84 @@
+const Task = require('../models/Task');
+
+const createTask = async (req, res) => {
+  try {
+    const task = await Task.create({
+      ...req.body,
+      userId: req.user.id,
+    });
+    res.status(201).json(task);
+  } catch (error) {
+    res.status(500).json({ error: 'Server error', details: error.message });
+  }
+};
+
+const getTasks = async (req, res) => {
+  try {
+    const where = { userId: req.user.id };
+    if (req.query.customerId) {
+      where.customerId = req.query.customerId;
+    }
+    if (req.query.leadId) {
+      where.leadId = req.query.leadId;
+    }
+    if (req.query.status) {
+      where.status = req.query.status;
+    }
+    const tasks = await Task.findAll({ where });
+    res.json(tasks);
+  } catch (error) {
+    res.status(500).json({ error: 'Server error', details: error.message });
+  }
+};
+
+const getTaskById = async (req, res) => {
+  try {
+    const task = await Task.findOne({
+      where: { id: req.params.id, userId: req.user.id },
+    });
+    if (!task) {
+      return res.status(404).json({ error: 'Task not found' });
+    }
+    res.json(task);
+  } catch (error) {
+    res.status(500).json({ error: 'Server error', details: error.message });
+  }
+};
+
+const updateTask = async (req, res) => {
+  try {
+    const [updated] = await Task.update(req.body, {
+      where: { id: req.params.id, userId: req.user.id },
+    });
+    if (!updated) {
+      return res.status(404).json({ error: 'Task not found' });
+    }
+    const updatedTask = await Task.findByPk(req.params.id);
+    res.json(updatedTask);
+  } catch (error) {
+    res.status(500).json({ error: 'Server error', details: error.message });
+  }
+};
+
+const deleteTask = async (req, res) => {
+  try {
+    const task = await Task.findOne({
+      where: { id: req.params.id, userId: req.user.id },
+    });
+    if (!task) {
+      return res.status(404).json({ error: 'Task not found' });
+    }
+    await task.destroy();
+    res.status(204).end();
+  } catch (error) {
+    res.status(500).json({ error: 'Server error', details: error.message });
+  }
+};
+
+module.exports = {
+  createTask,
+  getTasks,
+  getTaskById,
+  updateTask,
+  deleteTask,
+};

--- a/backend/index.js
+++ b/backend/index.js
@@ -18,6 +18,7 @@ const LimitsRoutes = require('./routes/LimiteRoutes');
 const projectRoutes = require('./routes/projectRoutes');
 const pixelRoutes = require('./routes/pixelRoutes');
 const crmRoutes = require('./routes/crmRoutes');
+const taskRoutes = require('./routes/taskRoutes');
 const customDomainRoutes = require('./routes/customDomainRoutes');
 const statsRoutes = require('./routes/statsRoutes');
 const sequelize = require('./database/sequelize');
@@ -167,6 +168,7 @@ app.use('/limits', LimitsRoutes);
 app.use('/project', projectRoutes);
 app.use('/pixel', pixelRoutes);
 app.use('/crm', requireAuth, crmRoutes);
+app.use('/tasks', requireAuth, taskRoutes);
 app.use('/custom-domain', customDomainRoutes);
 app.use('/', statsRoutes);
 

--- a/backend/models/Customer.js
+++ b/backend/models/Customer.js
@@ -53,6 +53,11 @@ Customer.associate = (models) => {
     as: 'Interactions',
     onDelete: 'CASCADE'
   });
+  Customer.hasMany(models.Task, {
+    foreignKey: 'customerId',
+    as: 'Tasks',
+    onDelete: 'SET NULL'
+  });
 };
 
 module.exports = Customer;

--- a/backend/models/Lead.js
+++ b/backend/models/Lead.js
@@ -52,6 +52,11 @@ Lead.associate = (models) => {
     as: 'Interactions',
     onDelete: 'CASCADE'
   });
+  Lead.hasMany(models.Task, {
+    foreignKey: 'leadId',
+    as: 'Tasks',
+    onDelete: 'SET NULL'
+  });
 };
 
 module.exports = Lead;

--- a/backend/models/Task.js
+++ b/backend/models/Task.js
@@ -1,0 +1,67 @@
+const { DataTypes } = require('sequelize');
+const sequelize = require('../database/sequelize');
+
+const Task = sequelize.define('Task', {
+  id: {
+    type: DataTypes.INTEGER,
+    primaryKey: true,
+    autoIncrement: true,
+  },
+  title: {
+    type: DataTypes.STRING,
+    allowNull: false,
+  },
+  dueDate: {
+    type: DataTypes.DATE,
+    allowNull: false,
+    field: 'due_date',
+  },
+  status: {
+    type: DataTypes.STRING,
+    allowNull: false,
+    defaultValue: 'pending',
+  },
+  userId: {
+    type: DataTypes.INTEGER,
+    allowNull: false,
+    references: {
+      model: 'users',
+      key: 'id',
+    },
+    onDelete: 'CASCADE',
+    field: 'user_id',
+  },
+  customerId: {
+    type: DataTypes.INTEGER,
+    allowNull: true,
+    references: {
+      model: 'customers',
+      key: 'id',
+    },
+    onDelete: 'SET NULL',
+    field: 'customer_id',
+  },
+  leadId: {
+    type: DataTypes.INTEGER,
+    allowNull: true,
+    references: {
+      model: 'leads',
+      key: 'id',
+    },
+    onDelete: 'SET NULL',
+    field: 'lead_id',
+  },
+}, {
+  tableName: 'tasks',
+  timestamps: true,
+  createdAt: 'created_at',
+  updatedAt: 'updated_at',
+});
+
+Task.associate = (models) => {
+  Task.belongsTo(models.Users, { foreignKey: 'userId', as: 'Users' });
+  Task.belongsTo(models.Customer, { foreignKey: 'customerId', as: 'Customer' });
+  Task.belongsTo(models.Lead, { foreignKey: 'leadId', as: 'Lead' });
+};
+
+module.exports = Task;

--- a/backend/routes/taskRoutes.js
+++ b/backend/routes/taskRoutes.js
@@ -1,0 +1,11 @@
+const express = require('express');
+const router = express.Router();
+const taskController = require('../controllers/taskController');
+
+router.post('/', taskController.createTask);
+router.get('/', taskController.getTasks);
+router.get('/:id', taskController.getTaskById);
+router.put('/:id', taskController.updateTask);
+router.delete('/:id', taskController.deleteTask);
+
+module.exports = router;

--- a/crm.sql
+++ b/crm.sql
@@ -39,3 +39,18 @@ CREATE TABLE IF NOT EXISTS `interactions` (
   CONSTRAINT `fk_interactions_customer` FOREIGN KEY (`customerId`) REFERENCES `customers`(`id`) ON DELETE CASCADE,
   CONSTRAINT `fk_interactions_lead` FOREIGN KEY (`leadId`) REFERENCES `leads`(`id`) ON DELETE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE IF NOT EXISTS `tasks` (
+  `id` INT AUTO_INCREMENT PRIMARY KEY,
+  `title` VARCHAR(255) NOT NULL,
+  `due_date` DATETIME NOT NULL,
+  `status` VARCHAR(50) NOT NULL DEFAULT 'pending',
+  `user_id` INT NOT NULL,
+  `customer_id` INT DEFAULT NULL,
+  `lead_id` INT DEFAULT NULL,
+  `created_at` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `updated_at` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  CONSTRAINT `fk_tasks_user` FOREIGN KEY (`user_id`) REFERENCES `users`(`id`) ON DELETE CASCADE,
+  CONSTRAINT `fk_tasks_customer` FOREIGN KEY (`customer_id`) REFERENCES `customers`(`id`) ON DELETE SET NULL,
+  CONSTRAINT `fk_tasks_lead` FOREIGN KEY (`lead_id`) REFERENCES `leads`(`id`) ON DELETE SET NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -48,6 +48,7 @@ import AuthHandler from './authentification/AuthHandler';
 import LeadsPage from './pages/LeadsPage';
 import CustomersPage from './pages/CustomersPage';
 import InteractionFormPage from './pages/InteractionForm';
+import TasksPage from './pages/TasksPage';
 
 function App() {
   const { isLoading, user } = useAuth(); 
@@ -116,6 +117,7 @@ function App() {
               <Route path="leads" element={<LeadsPage />} />
               <Route path="customers" element={<CustomersPage />} />
               <Route path="interactions/:id" element={<InteractionFormPage />} />
+              <Route path="tasks/:id" element={<TasksPage />} />
             </Route>
           </Route>
 
@@ -155,6 +157,7 @@ function App() {
               <Route path="leads" element={<LeadsPage />} />
               <Route path="customers" element={<CustomersPage />} />
               <Route path="interactions/:id" element={<InteractionFormPage />} />
+              <Route path="tasks/:id" element={<TasksPage />} />
             </Route>
             <Route path="subscriptions">
               <Route index element={<ListSubscriptions />} />

--- a/frontend/src/pages/CustomersPage.tsx
+++ b/frontend/src/pages/CustomersPage.tsx
@@ -210,21 +210,31 @@ const CustomersPage: React.FC = () => {
                   <td className="px-4 py-4 whitespace-nowrap text-sm text-gray-500 dark:text-gray-400">{customer.phone}</td>
                   <td className="px-4 py-4 whitespace-nowrap text-sm text-gray-500 dark:text-gray-400">{customer.status}</td>
                   <td className="px-4 py-4 whitespace-nowrap text-sm space-x-2">
-                    <button
-                      className="text-blue-600"
-                      onClick={() =>
-                        navigate(
-                          `${basePath}/crm/interactions/${customer.id}?type=customer`
-                        )
-                      }
-                    >
-                      Interactions
-                    </button>
-                    <button
-                      className="text-green-600"
-                      onClick={() => handleEdit(customer)}
-                    >
-                      Edit
+                  <button
+                    className="text-blue-600"
+                    onClick={() =>
+                      navigate(
+                        `${basePath}/crm/interactions/${customer.id}?type=customer`
+                      )
+                    }
+                  >
+                    Interactions
+                  </button>
+                  <button
+                    className="text-purple-600"
+                    onClick={() =>
+                      navigate(
+                        `${basePath}/crm/tasks/${customer.id}?type=customer`
+                      )
+                    }
+                  >
+                    Tasks
+                  </button>
+                  <button
+                    className="text-green-600"
+                    onClick={() => handleEdit(customer)}
+                  >
+                    Edit
                     </button>
                     <button
                       className="text-red-600"

--- a/frontend/src/pages/LeadsPage.tsx
+++ b/frontend/src/pages/LeadsPage.tsx
@@ -247,6 +247,16 @@ const LeadsPage: React.FC = () => {
                     Interactions
                   </button>
                   <button
+                    className="text-purple-600"
+                    onClick={() =>
+                      navigate(
+                        `${basePath}/crm/tasks/${lead.id}?type=lead`
+                      )
+                    }
+                  >
+                    Tasks
+                  </button>
+                  <button
                     className="text-green-600"
                     onClick={() => handleEdit(lead)}
                   >

--- a/frontend/src/pages/TasksPage.tsx
+++ b/frontend/src/pages/TasksPage.tsx
@@ -1,0 +1,209 @@
+import React, { useEffect, useState } from 'react';
+import { useParams, useSearchParams } from 'react-router-dom';
+import taskService, { Task } from '../services/taskService';
+
+const TasksPage: React.FC = () => {
+  const { id } = useParams<{ id: string }>();
+  const [searchParams] = useSearchParams();
+  const entityType =
+    (searchParams.get('type') === 'lead' ? 'leads' : 'customers') as 'customers' | 'leads';
+  const [tasks, setTasks] = useState<Task[]>([]);
+  const [form, setForm] = useState({ title: '', dueDate: '', status: 'pending' });
+  const [editingTask, setEditingTask] = useState<Task | null>(null);
+  const [editForm, setEditForm] = useState({ title: '', dueDate: '', status: 'pending' });
+
+  const loadTasks = () => {
+    if (!id) return;
+    const params: any = {
+      [entityType === 'customers' ? 'customerId' : 'leadId']: id,
+    };
+    taskService
+      .getTasks(params)
+      .then(data => setTasks(data))
+      .catch(err => console.error('Failed to load tasks', err));
+  };
+
+  useEffect(() => {
+    loadTasks();
+  }, [id, entityType]);
+
+  const handleChange = (
+    e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>
+  ) => {
+    setForm({ ...form, [e.target.name]: e.target.value });
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!id) return;
+    try {
+      const data = {
+        ...form,
+        [entityType === 'customers' ? 'customerId' : 'leadId']: id,
+      };
+      const newTask = await taskService.createTask(data);
+      setTasks([...tasks, newTask]);
+      setForm({ title: '', dueDate: '', status: 'pending' });
+    } catch (error) {
+      console.error('Failed to create task', error);
+    }
+  };
+
+  const handleEdit = (task: Task) => {
+    setEditingTask(task);
+    setEditForm({
+      title: task.title,
+      dueDate: task.dueDate ? task.dueDate.slice(0, 16) : '',
+      status: task.status || 'pending',
+    });
+  };
+
+  const handleEditChange = (
+    e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>
+  ) => {
+    setEditForm({ ...editForm, [e.target.name]: e.target.value });
+  };
+
+  const handleEditSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!editingTask) return;
+    try {
+      const updated = await taskService.updateTask(editingTask.id, editForm);
+      setTasks(tasks.map(t => (t.id === editingTask.id ? updated : t)));
+      setEditingTask(null);
+    } catch (error) {
+      console.error('Failed to update task', error);
+    }
+  };
+
+  const handleDelete = async (taskId: string) => {
+    try {
+      await taskService.deleteTask(taskId);
+      setTasks(tasks.filter(t => t.id !== taskId));
+    } catch (error) {
+      console.error('Failed to delete task', error);
+    }
+  };
+
+  if (!id) {
+    return <div>No target selected</div>;
+  }
+
+  return (
+    <div className="space-y-4 py-6">
+      <h1 className="text-2xl font-semibold">Tasks</h1>
+      <form onSubmit={handleSubmit} className="space-y-2 max-w-sm">
+        <input
+          name="title"
+          value={form.title}
+          onChange={handleChange}
+          placeholder="Title"
+          className="w-full p-2 border rounded"
+        />
+        <input
+          type="datetime-local"
+          name="dueDate"
+          value={form.dueDate}
+          onChange={handleChange}
+          className="w-full p-2 border rounded"
+        />
+        <select
+          name="status"
+          value={form.status}
+          onChange={handleChange}
+          className="w-full p-2 border rounded"
+        >
+          <option value="pending">Pending</option>
+          <option value="completed">Completed</option>
+        </select>
+        <button type="submit" className="px-4 py-2 bg-blue-600 text-white rounded">
+          Add Task
+        </button>
+      </form>
+
+      {editingTask && (
+        <form onSubmit={handleEditSubmit} className="space-y-2 max-w-sm">
+          <h2 className="text-xl font-semibold">Edit Task</h2>
+          <input
+            name="title"
+            value={editForm.title}
+            onChange={handleEditChange}
+            placeholder="Title"
+            className="w-full p-2 border rounded"
+          />
+          <input
+            type="datetime-local"
+            name="dueDate"
+            value={editForm.dueDate}
+            onChange={handleEditChange}
+            className="w-full p-2 border rounded"
+          />
+          <select
+            name="status"
+            value={editForm.status}
+            onChange={handleEditChange}
+            className="w-full p-2 border rounded"
+          >
+            <option value="pending">Pending</option>
+            <option value="completed">Completed</option>
+          </select>
+          <button type="submit" className="px-4 py-2 bg-green-600 text-white rounded">
+            Save
+          </button>
+        </form>
+      )}
+
+      <div className="overflow-x-auto">
+        <table className="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
+          <thead className="bg-gray-50 dark:bg-gray-700">
+            <tr>
+              <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
+                Title
+              </th>
+              <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
+                Due Date
+              </th>
+              <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
+                Status
+              </th>
+              <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
+                Actions
+              </th>
+            </tr>
+          </thead>
+          <tbody className="bg-white dark:bg-gray-800 divide-y divide-gray-200 dark:divide-gray-700">
+            {tasks.map(task => (
+              <tr key={task.id} className="hover:bg-gray-50 dark:hover:bg-gray-700">
+                <td className="px-4 py-4 whitespace-nowrap text-sm text-gray-900 dark:text-gray-200">
+                  {task.title}
+                </td>
+                <td className="px-4 py-4 whitespace-nowrap text-sm text-gray-500 dark:text-gray-400">
+                  {task.dueDate ? new Date(task.dueDate).toLocaleString() : ''}
+                </td>
+                <td className="px-4 py-4 whitespace-nowrap text-sm text-gray-500 dark:text-gray-400">
+                  {task.status}
+                </td>
+                <td className="px-4 py-4 whitespace-nowrap text-sm space-x-2">
+                  <button
+                    className="text-green-600"
+                    onClick={() => handleEdit(task)}
+                  >
+                    Edit
+                  </button>
+                  <button
+                    className="text-red-600"
+                    onClick={() => handleDelete(task.id)}
+                  >
+                    Delete
+                  </button>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+};
+
+export default TasksPage;

--- a/frontend/src/services/taskService.ts
+++ b/frontend/src/services/taskService.ts
@@ -1,0 +1,36 @@
+import axios from 'axios';
+import { getToken } from './tokenService';
+
+const api = axios.create({
+  baseURL: `${import.meta.env.VITE_API_BASE_URL || 'http://localhost:3000'}/tasks`,
+  timeout: Number(import.meta.env.VITE_API_TIMEOUT) || 30000,
+});
+
+api.interceptors.request.use(config => {
+  const token = getToken();
+  if (token) {
+    config.headers.Authorization = `Bearer ${token}`;
+  }
+  return config;
+});
+
+export interface Task {
+  id: string;
+  title: string;
+  dueDate?: string;
+  status?: string;
+  customerId?: string;
+  leadId?: string;
+}
+
+export const taskService = {
+  getTasks: (params?: { customerId?: string; leadId?: string; status?: string }) =>
+    api.get<Task[]>('/', { params }).then(res => res.data),
+  getTask: (id: string) => api.get<Task>(`/${id}`).then(res => res.data),
+  createTask: (data: Partial<Task>) => api.post('/', data).then(res => res.data),
+  updateTask: (id: string, data: Partial<Task>) =>
+    api.put(`/${id}`, data).then(res => res.data),
+  deleteTask: (id: string) => api.delete(`/${id}`),
+};
+
+export default taskService;


### PR DESCRIPTION
## Summary
- add tasks table to SQL schema with user, customer, and lead relations

## Testing
- `npm test` (backend) *(fails: jest not found)*
- `npm test` (frontend) *(fails: missing script)*
- `npm run lint` (frontend) *(fails: 145 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b468598dfc832f91d5d67751af7946