### PR TITLE
Fix missing bracket in Lead model associations

### DIFF
--- a/backend/models/Lead.js
+++ b/backend/models/Lead.js
@@ -56,6 +56,7 @@ Lead.associate = (models) => {
     foreignKey: 'leadId',
     as: 'Tasks',
     onDelete: 'SET NULL'
+  });
   Lead.belongsToMany(models.Tag, {
     through: models.LeadTag,
     foreignKey: 'leadId',


### PR DESCRIPTION
## Summary
- close the `Lead.hasMany(models.Task)` association and ensure `Lead.belongsToMany(models.Tag)` loads correctly

## Testing
- `npm test` *(fails: sh: 1: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b46dd0da1c832fbc1642df3d259852