### PR TITLE
refactor: remove vcard from leads

### DIFF
--- a/backend/controllers/crmController.js
+++ b/backend/controllers/crmController.js
@@ -103,8 +103,9 @@ const deleteCustomer = async (req, res) => {
 // Lead CRUD
 const createLead = async (req, res) => {
   try {
+    const { vcardId, ...leadData } = req.body;
     const lead = await Lead.create({
-      ...req.body,
+      ...leadData,
       userId: req.user.id,
     });
     res.status(201).json(lead);
@@ -166,7 +167,8 @@ const getLeadById = async (req, res) => {
 
 const updateLead = async (req, res) => {
   try {
-    const [updated] = await Lead.update(req.body, {
+    const { vcardId, ...updateData } = req.body;
+    const [updated] = await Lead.update(updateData, {
       where: { id: req.params.id, userId: req.user.id },
     });
     if (!updated) {
@@ -214,7 +216,7 @@ const convertLeadToCustomer = async (req, res) => {
       status: req.body.status || lead.status,
       notes: lead.notes,
       userId: lead.userId,
-      vcardId: lead.vcardId || req.body.vcardId,
+      vcardId: req.body.vcardId || null,
     });
 
     if (lead.Tags && lead.Tags.length) {

--- a/backend/models/Lead.js
+++ b/backend/models/Lead.js
@@ -34,15 +34,6 @@ const Lead = sequelize.define('Lead', {
   notes: {
     type: DataTypes.TEXT,
     allowNull: true
-  },
-  vcardId: {
-    type: DataTypes.INTEGER,
-    allowNull: true,
-    references: {
-      model: 'vcards',
-      key: 'id'
-    },
-    onDelete: 'SET NULL'
   }
 }, {
   tableName: 'leads',
@@ -55,10 +46,6 @@ Lead.associate = (models) => {
   Lead.belongsTo(models.Users, {
     foreignKey: 'userId',
     as: 'Users'
-  });
-  Lead.belongsTo(models.VCard, {
-    foreignKey: 'vcardId',
-    as: 'Vcard'
   });
   Lead.hasMany(models.Interaction, {
     foreignKey: 'leadId',

--- a/frontend/src/pages/CustomersPage.tsx
+++ b/frontend/src/pages/CustomersPage.tsx
@@ -34,7 +34,7 @@ const CustomersPage: React.FC = () => {
   useEffect(() => {
     if (!user) return;
     vcardService
-      .getAll(user.id)
+      .getAll(String(user.id))
       .then(setVcards)
       .catch(err => console.error('Failed to load vcards', err));
   }, [user]);

--- a/frontend/src/pages/LeadsPage.tsx
+++ b/frontend/src/pages/LeadsPage.tsx
@@ -1,18 +1,15 @@
 import React, { useEffect, useState } from 'react';
 import { crmService, Lead, Tag } from '../services/crmService';
-import { vcardService } from '../services/api';
-import { VCard } from '../services/vcard';
-import { useAuth } from '../context/AuthContext';
 import PipelineStage from '../components/PipelineStage';
 import { useNavigate, useLocation } from 'react-router-dom';
 
 const LeadsPage: React.FC = () => {
   const [leads, setLeads] = useState<Lead[]>([]);
   const [stageFilter, setStageFilter] = useState<string>();
-  const [form, setForm] = useState({ name: '', email: '', phone: '', status: 'New', notes: '', vcardId: '' });
+  const [form, setForm] = useState({ name: '', email: '', phone: '', status: 'New', notes: '' });
   const [formTags, setFormTags] = useState<string[]>([]);
   const [editingLead, setEditingLead] = useState<Lead | null>(null);
-  const [editForm, setEditForm] = useState({ name: '', email: '', phone: '', status: '', notes: '', vcardId: '' });
+  const [editForm, setEditForm] = useState({ name: '', email: '', phone: '', status: '', notes: '' });
   const [editFormTags, setEditFormTags] = useState<string[]>([]);
   const [search, setSearch] = useState('');
   const [sortBy, setSortBy] = useState('name');
@@ -20,8 +17,6 @@ const LeadsPage: React.FC = () => {
   const [tags, setTags] = useState<Tag[]>([]);
   const [newTag, setNewTag] = useState('');
   const [filterTags, setFilterTags] = useState<string[]>([]);
-  const [vcards, setVcards] = useState<VCard[]>([]);
-  const { user } = useAuth();
   const navigate = useNavigate();
   const location = useLocation();
   const basePath = location.pathname.startsWith('/super-admin') ? '/super-admin' : '/admin';
@@ -33,13 +28,7 @@ const LeadsPage: React.FC = () => {
       .catch(err => console.error('Failed to load tags', err));
   }, []);
 
-  useEffect(() => {
-    if (!user) return;
-    vcardService
-      .getAll(user.id)
-      .then(setVcards)
-      .catch(err => console.error('Failed to load vcards', err));
-  }, [user]);
+  // Leads no longer require vCards, so we do not load them here.
 
   useEffect(() => {
     crmService
@@ -98,7 +87,7 @@ const LeadsPage: React.FC = () => {
       }
       const refreshed = await crmService.getLeads({ search, sortBy, order, tags: filterTags });
       setLeads(refreshed);
-        setForm({ name: '', email: '', phone: '', status: 'New', notes: '', vcardId: '' });
+      setForm({ name: '', email: '', phone: '', status: 'New', notes: '' });
       setFormTags([]);
     } catch (error) {
       console.error('Failed to create lead', error);
@@ -132,7 +121,6 @@ const LeadsPage: React.FC = () => {
       phone: lead.phone || '',
       status: lead.status || 'New',
       notes: lead.notes || '',
-      vcardId: lead.vcardId || '',
     });
     setEditFormTags(lead.Tags?.map(t => t.id.toString()) || []);
   };
@@ -260,19 +248,6 @@ const LeadsPage: React.FC = () => {
             </option>
           ))}
         </select>
-        <select
-          name="vcardId"
-          value={form.vcardId}
-          onChange={handleChange}
-          className="w-full p-2 border rounded"
-        >
-          <option value="">No VCard</option>
-          {vcards.map(vcard => (
-            <option key={vcard.id} value={vcard.id}>
-              {vcard.name}
-            </option>
-          ))}
-        </select>
         <textarea
           name="notes"
           value={form.notes}
@@ -333,24 +308,11 @@ const LeadsPage: React.FC = () => {
             </option>
           ))}
         </select>
-        <select
-          name="vcardId"
-          value={editForm.vcardId}
-          onChange={handleEditChange}
-          className="w-full p-2 border rounded"
-        >
-          <option value="">No VCard</option>
-          {vcards.map(vcard => (
-            <option key={vcard.id} value={vcard.id}>
-              {vcard.name}
-            </option>
-          ))}
-        </select>
-        <textarea
-          name="notes"
-          value={editForm.notes}
-          onChange={handleEditChange}
-          placeholder="Notes"
+          <textarea
+            name="notes"
+            value={editForm.notes}
+            onChange={handleEditChange}
+            placeholder="Notes"
             className="w-full p-2 border rounded"
           />
           <button type="submit" className="px-4 py-2 bg-green-600 text-white rounded">

--- a/frontend/src/services/crmService.ts
+++ b/frontend/src/services/crmService.ts
@@ -26,7 +26,6 @@ export interface Lead {
   phone?: string;
   status?: string;
   notes?: string;
-  vcardId?: string;
   Tags?: Tag[];
 }
 


### PR DESCRIPTION
## Summary
- fetch vcards using stringified user id when managing customers
- drop vcard field from lead model and CRM controller
- simplify lead creation/edit UI by removing vcard selection

## Testing
- `npm test` *(fails: jest: not found)*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/jest)*
- `npm test` in frontend *(fails: Missing script "test")*
- `npm run lint` *(fails: 126 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b473ad3230832fa84319260eb81720