### PR TITLE
Fix vCard list fetching for CRM customers

### DIFF
--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -207,7 +207,10 @@ export const vcardService = {
   getAll: async (userId: string) => {
     try {
       const response = await api.get(`/vcard?userId=${userId}`);
-      return response.data;
+      // Some endpoints return the vCards array directly while others
+      // wrap it in a `data` property. Normalize the response so callers
+      // always receive an array of vCards.
+      return Array.isArray(response.data) ? response.data : response.data?.data || [];
     } catch (error) {
       console.error('Error getting all vcards:', error);
       throw error;


### PR DESCRIPTION
## Summary
- normalize vCard API response so all callers receive a consistent array

## Testing
- `npm test` *(fails: jest not found)*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/jest)*

------
https://chatgpt.com/codex/tasks/task_e_68b47585dc38832fa56c52749bb4debe