### PR TITLE
Link CRM customers to vCards

### DIFF
--- a/frontend/src/pages/CustomersPage.tsx
+++ b/frontend/src/pages/CustomersPage.tsx
@@ -117,7 +117,7 @@ const CustomersPage: React.FC = () => {
       phone: customer.phone || '',
       status: customer.status || '',
       notes: customer.notes || '',
-      vcardId: customer.vcardId || '',
+      vcardId: customer.vcardId ? String(customer.vcardId) : '',
     });
     setEditFormTags(customer.Tags?.map(t => t.id.toString()) || []);
   };
@@ -363,7 +363,7 @@ const CustomersPage: React.FC = () => {
                     {customer.Tags?.map(t => t.name).join(', ')}
                   </td>
                   <td className="px-4 py-4 whitespace-nowrap text-sm text-gray-500 dark:text-gray-400">
-                    {vcards.find(v => v.id === customer.vcardId)?.name || ''}
+                    {customer.Vcard?.name || ''}
                   </td>
                   <td className="px-4 py-4 whitespace-nowrap text-sm space-x-2">
                   <button

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -207,7 +207,10 @@ export const vcardService = {
   getAll: async (userId: string) => {
     try {
       const response = await api.get(`/vcard?userId=${userId}`);
-      return response.data;
+      // Some endpoints return the vCards array directly while others
+      // wrap it in a `data` property. Normalize the response so callers
+      // always receive an array of vCards.
+      return Array.isArray(response.data) ? response.data : response.data?.data || [];
     } catch (error) {
       console.error('Error getting all vcards:', error);
       throw error;

--- a/frontend/src/services/crmService.ts
+++ b/frontend/src/services/crmService.ts
@@ -1,5 +1,6 @@
 import axios from 'axios';
 import { getToken } from './tokenService';
+import type { VCard } from './vcard';
 
 const api = axios.create({
   baseURL: `${import.meta.env.VITE_API_BASE_URL || 'http://localhost:3000'}/crm`,
@@ -37,6 +38,7 @@ export interface Customer {
   status?: string;
   notes?: string;
   vcardId?: string;
+  Vcard?: Pick<VCard, 'id' | 'name'>;
   Tags?: Tag[];
 }
 


### PR DESCRIPTION
## Summary
- include associated vCard info when fetching CRM customers so their names are available
- expose customer vCard details to the client and render the vCard name in the list

## Testing
- `npm test` *(fails: jest: not found)*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/jest)*
- `npm test` *(fails: missing script "test" in frontend)*
- `npm run lint` *(terminated after no response)*

------
https://chatgpt.com/codex/tasks/task_e_68b47585dc38832fa56c52749bb4debe