### PR TITLE
Handle missing vCard when creating customers

### DIFF
--- a/backend/controllers/crmController.js
+++ b/backend/controllers/crmController.js
@@ -8,8 +8,18 @@ const { Op } = require('sequelize');
 // Customer CRUD
 const createCustomer = async (req, res) => {
   try {
+    // Clean payload to avoid sending invalid data (e.g. empty strings for integers)
+    const { vcardId, ...payload } = req.body;
+
+    // Only include vcardId if it is a valid number. An empty string or undefined
+    // causes Sequelize/MySQL to throw an error which resulted in a 500 response
+    // when creating a customer without selecting a vCard.
+    if (vcardId !== undefined && vcardId !== null && vcardId !== '') {
+      payload.vcardId = parseInt(vcardId, 10);
+    }
+
     const customer = await Customer.create({
-      ...req.body,
+      ...payload,
       userId: req.user.id,
     });
     res.status(201).json(customer);


### PR DESCRIPTION
## Summary
- avoid 500 errors when creating a customer without a vCard selection by ignoring empty vcardId values

## Testing
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b47a0def68832f91b6fa65768a0551