### PR TITLE
Remove vCard linking to customers

### DIFF
--- a/backend/controllers/crmController.js
+++ b/backend/controllers/crmController.js
@@ -347,25 +347,6 @@ const unassignTagFromCustomer = async (req, res) => {
   }
 };
 
-const linkVcardToCustomer = async (req, res) => {
-  try {
-    const customer = await Customer.findOne({
-      where: { id: req.params.id, userId: req.user.id },
-    });
-    if (!customer) {
-      return res.status(404).json({ error: 'Customer not found' });
-    }
-    customer.vcardId = req.body.vcardId;
-    await customer.save();
-    await customer.reload({
-      include: [{ model: VCard, as: 'Vcard', attributes: ['id', 'name'] }],
-    });
-    res.json(customer);
-  } catch (error) {
-    res.status(500).json({ error: 'Server error', details: error.message });
-  }
-};
-
 const assignTagToLead = async (req, res) => {
   try {
     const lead = await Lead.findOne({
@@ -542,7 +523,6 @@ module.exports = {
   deleteTag,
   assignTagToCustomer,
   unassignTagFromCustomer,
-  linkVcardToCustomer,
   assignTagToLead,
   unassignTagFromLead,
   getInteractionsByCustomer,

--- a/backend/routes/crmRoutes.js
+++ b/backend/routes/crmRoutes.js
@@ -13,7 +13,6 @@ router.get('/customers/:id/interactions', requireAuth, crmController.getInteract
 router.post('/customers/:id/interactions', requireAuth, crmController.createInteractionForCustomer);
 router.post('/customers/:id/tags/:tagId', requireAuth, crmController.assignTagToCustomer);
 router.delete('/customers/:id/tags/:tagId', requireAuth, crmController.unassignTagFromCustomer);
-router.put('/customers/:id/vcard', requireAuth, crmController.linkVcardToCustomer);
 
 // Lead routes
 router.post('/leads', requireAuth, crmController.createLead);

--- a/frontend/src/pages/CustomersPage.tsx
+++ b/frontend/src/pages/CustomersPage.tsx
@@ -85,9 +85,6 @@ const CustomersPage: React.FC = () => {
     e.preventDefault();
     try {
       const newCustomer = await crmService.createCustomer(form);
-      if (form.vcardId) {
-        await crmService.linkVcardToCustomer(newCustomer.id, form.vcardId);
-      }
       for (const tagId of formTags) {
         await crmService.assignTagToCustomer(newCustomer.id, tagId);
       }
@@ -127,9 +124,6 @@ const CustomersPage: React.FC = () => {
     if (!editingCustomer) return;
     try {
       await crmService.updateCustomer(editingCustomer.id, editForm);
-      if (editForm.vcardId) {
-        await crmService.linkVcardToCustomer(editingCustomer.id, editForm.vcardId);
-      }
       const prev = editingCustomer.Tags?.map(t => t.id.toString()) || [];
       const toAdd = editFormTags.filter(id => !prev.includes(id));
       const toRemove = prev.filter(id => !editFormTags.includes(id));

--- a/frontend/src/services/crmService.ts
+++ b/frontend/src/services/crmService.ts
@@ -85,8 +85,6 @@ export const crmService = {
   updateCustomer: (id: string, data: Partial<Customer>) =>
     api.put(`/customers/${id}`, data).then(res => res.data),
   deleteCustomer: (id: string) => api.delete(`/customers/${id}`),
-  linkVcardToCustomer: (customerId: string, vcardId: string) =>
-    api.put(`/customers/${customerId}/vcard`, { vcardId }).then(res => res.data),
 
   createTag: (data: { name: string }) => api.post<Tag>('/tags', data).then(res => res.data),
   getTags: () => api.get<Tag[]>('/tags').then(res => res.data),


### PR DESCRIPTION
## Summary
- remove obsolete linkVcardToCustomer controller and route
- drop linkVcardToCustomer usage from CRM service and customers page

## Testing
- `npm test` *(fails: sh: 1: jest: not found)*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/jest)*

------
https://chatgpt.com/codex/tasks/task_e_68b56b01a5a0832f9f09736339c49d89