### PR TITLE
Add CRM stats page and sidebar link

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -49,6 +49,7 @@ import LeadsPage from './pages/LeadsPage';
 import CustomersPage from './pages/CustomersPage';
 import InteractionFormPage from './pages/InteractionForm';
 import TasksPage from './pages/TasksPage';
+import CRMStatsPage from './pages/CRMStatsPage';
 
 function App() {
   const { isLoading, user } = useAuth(); 
@@ -114,6 +115,7 @@ function App() {
               <Route path="edit/:id" element={<CustomDomainForm />} />
             </Route>
             <Route path="crm">
+              <Route path="stats" element={<CRMStatsPage />} />
               <Route path="leads" element={<LeadsPage />} />
               <Route path="customers" element={<CustomersPage />} />
               <Route path="interactions/:id" element={<InteractionFormPage />} />
@@ -154,6 +156,7 @@ function App() {
               <Route index element={<ListCustomDomains />} />
             </Route>
             <Route path="crm">
+              <Route path="stats" element={<CRMStatsPage />} />
               <Route path="leads" element={<LeadsPage />} />
               <Route path="customers" element={<CustomersPage />} />
               <Route path="interactions/:id" element={<InteractionFormPage />} />

--- a/frontend/src/pages/CRMStatsPage.tsx
+++ b/frontend/src/pages/CRMStatsPage.tsx
@@ -1,0 +1,80 @@
+import React, { useEffect, useState } from 'react';
+import { crmService } from '../services/crmService';
+import taskService, { Task } from '../services/taskService';
+
+function formatDate(iso?: string) {
+  if (!iso) return '';
+  try {
+    return new Date(iso).toLocaleDateString();
+  } catch {
+    return iso as string;
+  }
+}
+
+const CRMStatsPage: React.FC = () => {
+  const [leadCount, setLeadCount] = useState(0);
+  const [customerCount, setCustomerCount] = useState(0);
+  const [reminders, setReminders] = useState<Task[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let ignore = false;
+    async function fetchData() {
+      try {
+        const [leads, customers, tasks] = await Promise.all([
+          crmService.getLeads(),
+          crmService.getCustomers(),
+          taskService.getTasks({ status: 'pending' })
+        ]);
+        if (!ignore) {
+          setLeadCount(leads.length);
+          setCustomerCount(customers.length);
+          setReminders(tasks);
+        }
+      } catch (err) {
+        console.error('Failed to load CRM stats', err);
+      } finally {
+        if (!ignore) setLoading(false);
+      }
+    }
+    fetchData();
+    return () => {
+      ignore = true;
+    };
+  }, []);
+
+  if (loading) {
+    return <div className="p-4">Loading...</div>;
+  }
+
+  return (
+    <div className="py-6">
+      <h1 className="text-2xl font-semibold mb-6">CRM Stats</h1>
+      <div className="grid gap-6 mb-8 md:grid-cols-2">
+        <div className="min-w-0 p-4 bg-white rounded-lg shadow-xs dark:bg-gray-800">
+          <h2 className="mb-4 text-lg font-semibold text-gray-600 dark:text-gray-300">Totals</h2>
+          <p className="text-gray-700 dark:text-gray-200">Leads: {leadCount}</p>
+          <p className="text-gray-700 dark:text-gray-200">Customers: {customerCount}</p>
+        </div>
+        <div className="min-w-0 p-4 bg-white rounded-lg shadow-xs dark:bg-gray-800">
+          <h2 className="mb-4 text-lg font-semibold text-gray-600 dark:text-gray-300">Reminders</h2>
+          {reminders.length === 0 ? (
+            <p className="text-gray-600 dark:text-gray-400">No reminders</p>
+          ) : (
+            <ul className="space-y-2">
+              {reminders.map(r => (
+                <li key={r.id} className="flex justify-between">
+                  <span>{r.title}</span>
+                  <span className="text-sm text-gray-500">{formatDate(r.dueDate)}</span>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default CRMStatsPage;
+

--- a/frontend/src/templateBack/SideBar.tsx
+++ b/frontend/src/templateBack/SideBar.tsx
@@ -117,6 +117,15 @@ const Sidebar: React.FC<SidebarProps> = ({
         label: 'CRM'
       },
       {
+        path: `${basePath}/crm/stats`,
+        icon: (
+          <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M4 19h16M8 17V9m4 8V5m4 12v-6" />
+          </svg>
+        ),
+        label: 'Stats'
+      },
+      {
         path: `${basePath}/crm/leads`,
         icon: (
           <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">


### PR DESCRIPTION
## Summary
- Add CRM statistics page displaying totals and reminders
- Expose CRM stats route for admins and super admins

## Testing
- `npm test` (frontend) *(fails: Missing script "test")*
- `npm run lint` (frontend) *(fails: Unexpected any, no-unused-vars, etc.)*
- `npm test` (backend) *(fails: sqlite3 package missing)*

------
https://chatgpt.com/codex/tasks/task_e_68b5a58dd470832f9ae364efaa0b563f