### PR TITLE
feat: add groq assistant to crm

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -21,6 +21,7 @@ const crmRoutes = require('./routes/crmRoutes');
 const taskRoutes = require('./routes/taskRoutes');
 const customDomainRoutes = require('./routes/customDomainRoutes');
 const statsRoutes = require('./routes/statsRoutes');
+const assistantRoutes = require('./routes/assistantRoutes');
 const sequelize = require('./database/sequelize');
 const { requireAuth } = require('./middleware/authMiddleware');
 const path = require("path");
@@ -169,6 +170,7 @@ app.use('/project', projectRoutes);
 app.use('/pixel', pixelRoutes);
 app.use('/crm', requireAuth, crmRoutes);
 app.use('/tasks', requireAuth, taskRoutes);
+app.use('/assistant', requireAuth, assistantRoutes);
 app.use('/custom-domain', customDomainRoutes);
 app.use('/', statsRoutes);
 

--- a/backend/routes/assistantRoutes.js
+++ b/backend/routes/assistantRoutes.js
@@ -1,0 +1,39 @@
+const express = require('express');
+const axios = require('axios');
+
+const router = express.Router();
+
+router.post('/chat', async (req, res) => {
+  const { message } = req.body;
+
+  if (!message) {
+    return res.status(400).json({ error: 'Message is required' });
+  }
+
+  try {
+    const response = await axios.post(
+      'https://api.groq.com/openai/v1/chat/completions',
+      {
+        model: process.env.GROQ_MODEL || 'llama3-8b-8192',
+        messages: [
+          { role: 'system', content: 'You are a helpful CRM assistant.' },
+          { role: 'user', content: message }
+        ]
+      },
+      {
+        headers: {
+          Authorization: `Bearer ${process.env.GROQ_API_KEY}`,
+          'Content-Type': 'application/json'
+        }
+      }
+    );
+
+    const reply = response.data.choices?.[0]?.message?.content || '';
+    res.json({ reply });
+  } catch (error) {
+    console.error('Groq API error:', error.response?.data || error.message);
+    res.status(500).json({ error: 'Failed to get response from assistant' });
+  }
+});
+
+module.exports = router;

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -50,6 +50,7 @@ import CustomersPage from './pages/CustomersPage';
 import InteractionFormPage from './pages/InteractionForm';
 import TasksPage from './pages/TasksPage';
 import CRMStatsPage from './pages/CRMStatsPage';
+import AssistantPage from './pages/AssistantPage';
 
 function App() {
   const { isLoading, user } = useAuth(); 
@@ -121,9 +122,10 @@ function App() {
               <Route path="interactions/:id" element={<InteractionFormPage />} />
               <Route path="tasks/:id" element={<TasksPage />} />
             </Route>
+            <Route path="assistant" element={<AssistantPage />} />
           </Route>
 
-          <Route path="/super-admin" element={<Layout role="superAdmin" />}>
+          <Route path="/super-admin" element={<Layout role="superAdmin" />}> 
             <Route index element={<Navigate to="dashboard" replace />} />
             <Route path="dashboard">
               <Route index element={<DashboardAdmin />} />
@@ -162,6 +164,7 @@ function App() {
               <Route path="interactions/:id" element={<InteractionFormPage />} />
               <Route path="tasks/:id" element={<TasksPage />} />
             </Route>
+            <Route path="assistant" element={<AssistantPage />} />
             <Route path="subscriptions">
               <Route index element={<ListSubscriptions />} />
             </Route>

--- a/frontend/src/pages/AssistantPage.tsx
+++ b/frontend/src/pages/AssistantPage.tsx
@@ -1,0 +1,69 @@
+import React, { useState } from 'react';
+import { assistantService } from '../services/assistantService';
+
+interface Message {
+  role: 'user' | 'assistant';
+  content: string;
+}
+
+const AssistantPage: React.FC = () => {
+  const [messages, setMessages] = useState<Message[]>([]);
+  const [input, setInput] = useState('');
+  const [loading, setLoading] = useState(false);
+
+  const sendMessage = async () => {
+    if (!input.trim()) return;
+    const userMessage: Message = { role: 'user', content: input };
+    setMessages(prev => [...prev, userMessage]);
+    setInput('');
+    setLoading(true);
+    try {
+      const reply = await assistantService.chat(userMessage.content);
+      setMessages(prev => [...prev, { role: 'assistant', content: reply }]);
+    } catch (error) {
+      setMessages(prev => [...prev, { role: 'assistant', content: 'Unable to fetch response.' }]);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleKey = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter') {
+      sendMessage();
+    }
+  };
+
+  return (
+    <div className="py-8">
+      <h1 className="text-2xl font-semibold mb-4">AI Assistant</h1>
+      <div className="border rounded p-4 h-96 overflow-y-auto mb-4 bg-white dark:bg-gray-800">
+        {messages.map((m, i) => (
+          <div key={i} className={`mb-2 ${m.role === 'user' ? 'text-right' : 'text-left'}`}>
+            <span className="inline-block px-2 py-1 rounded bg-gray-200 dark:bg-gray-700">
+              {m.content}
+            </span>
+          </div>
+        ))}
+        {loading && <div>Loading...</div>}
+      </div>
+      <div className="flex">
+        <input
+          className="flex-1 border rounded-l p-2"
+          value={input}
+          onChange={e => setInput(e.target.value)}
+          onKeyDown={handleKey}
+          placeholder="Ask something..."
+        />
+        <button
+          className="bg-blue-500 text-white px-4 rounded-r disabled:opacity-50"
+          onClick={sendMessage}
+          disabled={loading}
+        >
+          Send
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default AssistantPage;

--- a/frontend/src/services/assistantService.ts
+++ b/frontend/src/services/assistantService.ts
@@ -1,0 +1,22 @@
+import axios from 'axios';
+import { getToken } from './tokenService';
+
+const api = axios.create({
+  baseURL: `${import.meta.env.VITE_API_BASE_URL || 'http://localhost:3000'}/assistant`,
+  timeout: Number(import.meta.env.VITE_API_TIMEOUT) || 30000,
+});
+
+api.interceptors.request.use(config => {
+  const token = getToken();
+  if (token) {
+    config.headers.Authorization = `Bearer ${token}`;
+  }
+  return config;
+});
+
+export const assistantService = {
+  chat: async (message: string): Promise<string> => {
+    const response = await api.post('/chat', { message });
+    return response.data.reply as string;
+  },
+};

--- a/frontend/src/templateBack/SideBar.tsx
+++ b/frontend/src/templateBack/SideBar.tsx
@@ -142,6 +142,15 @@ const Sidebar: React.FC<SidebarProps> = ({
           </svg>
         ),
         label: 'Customers'
+      },
+      {
+        path: `${basePath}/assistant`,
+        icon: (
+          <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M8 10h.01M12 10h.01M16 10h.01M21 12c0 3.866-3.582 7-8 7a8.966 8.966 0 01-4-.9L3 20l1.9-5A8.966 8.966 0 013 12c0-3.866 3.582-7 8-7s8 3.134 8 7z" />
+          </svg>
+        ),
+        label: 'Assistant'
       }
     ];
 


### PR DESCRIPTION
## Summary
- add Groq-powered assistant backend route
- expose assistant via new sidebar entry and page
- wire frontend service and routes for AI help

## Testing
- `npm test` (frontend) *(fails: Missing script: "test")*
- `npm run lint` (frontend) *(fails: tokenService.ts:44:12 'e' is defined but never used)*
- `npm test` (backend) *(fails: ConnectionManager._loadDialectModule ...)*

------
https://chatgpt.com/codex/tasks/task_e_68b5c15b59f0832faa14f1af982b2a52