### PR TITLE
feat: allow unauthenticated assistant chat

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -170,7 +170,7 @@ app.use('/project', projectRoutes);
 app.use('/pixel', pixelRoutes);
 app.use('/crm', requireAuth, crmRoutes);
 app.use('/tasks', requireAuth, taskRoutes);
-app.use('/assistant', requireAuth, assistantRoutes);
+app.use('/assistant', assistantRoutes);
 app.use('/custom-domain', customDomainRoutes);
 app.use('/', statsRoutes);
 


### PR DESCRIPTION
## Summary
- remove `requireAuth` middleware from assistant routes to allow unauthenticated usage

## Testing
- `npm test` *(fails: Please install sqlite3 package manually)*

------
https://chatgpt.com/codex/tasks/task_e_68b5c40ac87c832faf8a9f7b8c6b4689