### PR TITLE
feat(crm): add lead stages

### DIFF
--- a/backend/migrations/20250206000000-add-stage-to-leads.js
+++ b/backend/migrations/20250206000000-add-stage-to-leads.js
@@ -1,0 +1,18 @@
+'use strict';
+
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.addColumn('leads', 'stage', {
+      type: Sequelize.ENUM('new', 'contacted', 'qualified', 'proposal', 'won', 'lost'),
+      allowNull: false,
+      defaultValue: 'new'
+    });
+  },
+
+  async down(queryInterface, Sequelize) {
+    await queryInterface.removeColumn('leads', 'stage');
+    if (queryInterface.sequelize.getDialect() === 'postgres') {
+      await queryInterface.sequelize.query('DROP TYPE IF EXISTS "enum_leads_stage";');
+    }
+  }
+};

--- a/backend/models/Lead.js
+++ b/backend/models/Lead.js
@@ -23,6 +23,11 @@ const Lead = sequelize.define('Lead', {
     type: DataTypes.STRING,
     allowNull: true
   },
+  stage: {
+    type: DataTypes.ENUM('new', 'contacted', 'qualified', 'proposal', 'won', 'lost'),
+    allowNull: false,
+    defaultValue: 'new'
+  },
   userId: {
     type: DataTypes.INTEGER,
     allowNull: false,

--- a/backend/routes/crmRoutes.js
+++ b/backend/routes/crmRoutes.js
@@ -4,6 +4,28 @@ const crmController = require('../controllers/crmController');
 const { requireAuth } = require('../middleware/authMiddleware');
 const uploadService = require('../services/uploadService');
 
+const allowedStages = ['new', 'contacted', 'qualified', 'proposal', 'won', 'lost'];
+
+const validateStageBody = (req, res, next) => {
+  const { stage } = req.body;
+  if (stage && !allowedStages.includes(stage)) {
+    return res.status(400).json({
+      error: `Invalid stage. Allowed values: ${allowedStages.join(', ')}`,
+    });
+  }
+  next();
+};
+
+const validateStageQuery = (req, res, next) => {
+  const { stage } = req.query;
+  if (stage && !allowedStages.includes(stage)) {
+    return res.status(400).json({
+      error: `Invalid stage. Allowed values: ${allowedStages.join(', ')}`,
+    });
+  }
+  next();
+};
+
 router.get('/stats', requireAuth, crmController.getStats);
 
 // Customer routes
@@ -20,10 +42,10 @@ router.post('/customers/:id/tags/:tagId', requireAuth, crmController.assignTagTo
 router.delete('/customers/:id/tags/:tagId', requireAuth, crmController.unassignTagFromCustomer);
 
 // Lead routes
-router.post('/leads', requireAuth, crmController.createLead);
-router.get('/leads', requireAuth, crmController.getLeads);
+router.post('/leads', requireAuth, validateStageBody, crmController.createLead);
+router.get('/leads', requireAuth, validateStageQuery, crmController.getLeads);
 router.get('/leads/:id', requireAuth, crmController.getLeadById);
-router.put('/leads/:id', requireAuth, crmController.updateLead);
+router.put('/leads/:id', requireAuth, validateStageBody, crmController.updateLead);
 router.post('/leads/:id/convert', requireAuth, crmController.convertLeadToCustomer);
 router.delete('/leads/:id', requireAuth, crmController.deleteLead);
 router.post('/leads/:id/convert', requireAuth, crmController.convertLeadToCustomer);

--- a/frontend/src/services/crmService.ts
+++ b/frontend/src/services/crmService.ts
@@ -26,6 +26,7 @@ export interface Lead {
   email?: string;
   phone?: string;
   status?: string;
+  stage?: 'new' | 'contacted' | 'qualified' | 'proposal' | 'won' | 'lost';
   notes?: string;
   Tags?: Tag[];
 }
@@ -58,6 +59,8 @@ export interface CRMStats {
   conversionRate: number;
   weeklyLeadCreation: { week: string; count: number }[];
   interactionsPerCustomer: { customerId: number; name: string | null; count: number }[];
+  stageCounts: Record<string, number>;
+  stageConversionRates: Record<string, number>;
 }
 
 export const crmService = {
@@ -67,6 +70,7 @@ export const crmService = {
     sortBy?: string;
     order?: 'asc' | 'desc';
     tags?: string[];
+    stage?: string;
   }) =>
     api
       .get<Lead[]>('/leads', {


### PR DESCRIPTION
## Summary
- add `stage` enum to leads with migration
- validate lead stages and report stage stats
- expose stage filtering and visualization in leads UI

## Testing
- `npx sequelize-cli db:migrate` *(fails: 403 Forbidden - GET https://registry.npmjs.org/sequelize-cli)*
- `npm test` *(fails: Please install sqlite3 package manually)*
- `npm run lint` *(fails: 188 problems)*

------
https://chatgpt.com/codex/tasks/task_e_68b6d0118650832fb37b7ce36319fea4