### PR TITLE
feat: add task reminders

### DIFF
--- a/backend/controllers/taskController.js
+++ b/backend/controllers/taskController.js
@@ -75,10 +75,27 @@ const deleteTask = async (req, res) => {
   }
 };
 
+const toggleReminder = async (req, res) => {
+  try {
+    const [updated] = await Task.update(
+      { reminderEnabled: req.body.reminderEnabled },
+      { where: { id: req.params.id, userId: req.user.id } }
+    );
+    if (!updated) {
+      return res.status(404).json({ error: 'Task not found' });
+    }
+    const updatedTask = await Task.findByPk(req.params.id);
+    res.json(updatedTask);
+  } catch (error) {
+    res.status(500).json({ error: 'Server error', details: error.message });
+  }
+};
+
 module.exports = {
   createTask,
   getTasks,
   getTaskById,
   updateTask,
   deleteTask,
+  toggleReminder,
 };

--- a/backend/index.js
+++ b/backend/index.js
@@ -23,6 +23,7 @@ const taskRoutes = require('./routes/taskRoutes');
 const customDomainRoutes = require('./routes/customDomainRoutes');
 const statsRoutes = require('./routes/statsRoutes');
 const assistantRoutes = require('./routes/assistantRoutes');
+require('./scripts/taskReminder');
 const sequelize = require('./database/sequelize');
 const { requireAuth } = require('./middleware/authMiddleware');
 const path = require("path");

--- a/backend/models/Task.js
+++ b/backend/models/Task.js
@@ -21,6 +21,18 @@ const Task = sequelize.define('Task', {
     allowNull: false,
     defaultValue: 'pending',
   },
+  reminderEnabled: {
+    type: DataTypes.BOOLEAN,
+    allowNull: false,
+    defaultValue: true,
+    field: 'reminder_enabled',
+  },
+  reminderSent: {
+    type: DataTypes.BOOLEAN,
+    allowNull: false,
+    defaultValue: false,
+    field: 'reminder_sent',
+  },
   userId: {
     type: DataTypes.INTEGER,
     allowNull: false,

--- a/backend/routes/taskRoutes.js
+++ b/backend/routes/taskRoutes.js
@@ -1,11 +1,15 @@
 const express = require('express');
 const router = express.Router();
+const { requireAuth } = require('../middleware/authMiddleware');
 const taskController = require('../controllers/taskController');
+
+router.use(requireAuth);
 
 router.post('/', taskController.createTask);
 router.get('/', taskController.getTasks);
 router.get('/:id', taskController.getTaskById);
 router.put('/:id', taskController.updateTask);
+router.patch('/:id/reminder', taskController.toggleReminder);
 router.delete('/:id', taskController.deleteTask);
 
 module.exports = router;

--- a/backend/scripts/taskReminder.js
+++ b/backend/scripts/taskReminder.js
@@ -1,0 +1,50 @@
+const cron = require('node-cron');
+const { Op } = require('sequelize');
+const Task = require('../models/Task');
+const User = require('../models/User');
+const Notification = require('../models/Notification');
+const { sendCustomEmail } = require('../services/emailService');
+
+const WINDOW_MINUTES = parseInt(process.env.REMINDER_WINDOW_MINUTES || '60', 10);
+
+async function checkDueTasks() {
+  const now = new Date();
+  const windowEnd = new Date(now.getTime() + WINDOW_MINUTES * 60000);
+  try {
+    const tasks = await Task.findAll({
+      where: {
+        reminderEnabled: true,
+        reminderSent: false,
+        status: 'pending',
+        dueDate: { [Op.between]: [now, windowEnd] },
+      },
+      include: [{ model: User, as: 'Users', attributes: ['email', 'name'] }],
+    });
+
+    for (const task of tasks) {
+      const message = `Task "${task.title}" is due at ${task.dueDate.toLocaleString()}`;
+      if (task.Users && task.Users.email) {
+        try {
+          await sendCustomEmail(task.Users.email, task.Users.name || '', {
+            subject: 'Task Reminder',
+            text: message,
+          });
+        } catch (err) {
+          await Notification.create({ userId: task.userId, title: 'Task Reminder', message });
+        }
+      } else {
+        await Notification.create({ userId: task.userId, title: 'Task Reminder', message });
+      }
+      task.reminderSent = true;
+      await task.save();
+    }
+  } catch (err) {
+    console.error('Error in task reminder job:', err);
+  }
+}
+
+if (process.env.NODE_ENV !== 'test') {
+  cron.schedule('*/30 * * * *', checkDueTasks);
+}
+
+module.exports = { checkDueTasks };

--- a/frontend/src/pages/CRMStatsPage.tsx
+++ b/frontend/src/pages/CRMStatsPage.tsx
@@ -151,7 +151,8 @@ const CRMStatsPage: React.FC = () => {
         taskService.getTasks({ status: 'pending' }),
       ]);
       setStats(s);
-      const sorted = [...tasks].sort((a, b) => {
+      const enabled = tasks.filter(t => t.reminderEnabled);
+      const sorted = [...enabled].sort((a, b) => {
         const da = parseISO(a.dueDate)?.getTime() ?? Infinity;
         const db = parseISO(b.dueDate)?.getTime() ?? Infinity;
         return da - db;

--- a/frontend/src/pages/TasksPage.tsx
+++ b/frontend/src/pages/TasksPage.tsx
@@ -134,6 +134,7 @@ const SkeletonRow: React.FC = () => (
     <td className="px-4 py-4"><div className="h-4 w-48 rounded bg-gray-200 dark:bg-gray-700" /></td>
     <td className="px-4 py-4"><div className="h-4 w-40 rounded bg-gray-200 dark:bg-gray-700" /></td>
     <td className="px-4 py-4"><div className="h-5 w-24 rounded-full bg-gray-200 dark:bg-gray-700" /></td>
+    <td className="px-4 py-4"><div className="h-5 w-24 rounded bg-gray-200 dark:bg-gray-700" /></td>
     <td className="px-4 py-4"><div className="h-8 w-32 rounded bg-gray-200 dark:bg-gray-700" /></td>
   </tr>
 );
@@ -315,6 +316,18 @@ const TasksPage: React.FC = () => {
       setTasks((ts) => ts.map((t) => (t.id === task.id ? updated : t)));
     } catch (error) {
       console.error('Failed to toggle task', error);
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const toggleReminder = async (task: Task) => {
+    setBusy(true);
+    try {
+      const updated = await taskService.toggleReminder(task.id, !task.reminderEnabled);
+      setTasks((ts) => ts.map((t) => (t.id === task.id ? updated : t)));
+    } catch (error) {
+      console.error('Failed to toggle reminder', error);
     } finally {
       setBusy(false);
     }
@@ -509,6 +522,7 @@ const TasksPage: React.FC = () => {
                 <Th>Title</Th>
                 <Th>Due Date</Th>
                 <Th>Status</Th>
+                <Th>Reminder</Th>
                 <Th className="text-right">Actions</Th>
               </tr>
             </thead>
@@ -518,7 +532,7 @@ const TasksPage: React.FC = () => {
                 : filtered.length === 0
                 ? (
                   <tr>
-                    <td colSpan={4} className="px-6 py-14 text-center">
+                    <td colSpan={5} className="px-6 py-14 text-center">
                       <div className="flex flex-col items-center gap-2">
                         <svg width="36" height="36" viewBox="0 0 24 24" className="text-gray-400">
                           <path fill="currentColor" d="M19 3H5a2 2 0 0 0-2 2v14l4-4h12a2 2 0 0 0 2-2V5a2 2 0 0 0-2-2Z" />
@@ -553,6 +567,15 @@ const TasksPage: React.FC = () => {
                         </div>
                       </Td>
                       <Td><Pill tone={toneByStatus(task.status)}>{task.status === 'completed' ? 'Completed' : 'Pending'}</Pill></Td>
+                      <Td>
+                        <input
+                          type="checkbox"
+                          className="h-4 w-4 accent-blue-600"
+                          checked={!!task.reminderEnabled}
+                          onChange={() => toggleReminder(task)}
+                          title={task.reminderEnabled ? 'Disable reminder' : 'Enable reminder'}
+                        />
+                      </Td>
                       <Td className="text-right whitespace-nowrap">
                         <div className="flex justify-end gap-2">
                           <ActionButton
@@ -617,6 +640,7 @@ const TasksPage: React.FC = () => {
                           <Pill tone={toneByStatus(task.status)}>{task.status === 'completed' ? 'Completed' : 'Pending'}</Pill>
                         </div>
                         <div className="mt-3 flex flex-wrap gap-2">
+                          <ActionButton tone="blue" label={task.reminderEnabled ? 'Disable' : 'Enable'} iconPath="M12 22a2 2 0 0 0 2-2h-4a2 2 0 0 0 2 2zm6-6V11c0-3.07-1.63-5.64-4.5-6.32V4a1.5 1.5 0 0 0-3 0v.68C7.63 5.36 6 7.92 6 11v5l-2 2h16l-2-2z" onClick={() => toggleReminder(task)} />
                           <ActionButton tone="green" label="Edit" iconPath="M3 17.25V21h3.75L17.81 9.94l-3.75-3.75z" onClick={() => handleEdit(task)} />
                           <ActionButton tone="red" label="Delete" iconPath="M6 7h12v13H6zM9 4h6v3H9z" onClick={() => setToDelete({ open: true, id: task.id, title: task.title })} />
                         </div>

--- a/frontend/src/services/taskService.ts
+++ b/frontend/src/services/taskService.ts
@@ -21,6 +21,7 @@ export interface Task {
   status?: string;
   customerId?: string;
   leadId?: string;
+  reminderEnabled?: boolean;
 }
 
 export const taskService = {
@@ -31,6 +32,8 @@ export const taskService = {
   updateTask: (id: string, data: Partial<Task>) =>
     api.put(`/${id}`, data).then(res => res.data),
   deleteTask: (id: string) => api.delete(`/${id}`),
+  toggleReminder: (id: string, reminderEnabled: boolean) =>
+    api.patch(`/${id}/reminder`, { reminderEnabled }).then(res => res.data),
 };
 
 export default taskService;


### PR DESCRIPTION
## Summary
- add node-cron scheduler to notify users of upcoming tasks
- secure task routes and enable per-task reminder toggles
- expose reminder settings in UI and show upcoming reminders on CRM stats

## Testing
- `npm test` (backend) *(fails: Cannot find module '../../controllers/customDomainController', Cannot find module '../../controllers/planController', Cannot find module '../../controllers/projectController', Cannot find module 'csv-parser')*
- `npm test` (frontend) *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b6d2e0cd60832f84007a1cb7ed4288