### PR TITLE
Add customer-to-user conversion workflow

### DIFF
--- a/backend/routes/crmRoutes.js
+++ b/backend/routes/crmRoutes.js
@@ -40,6 +40,7 @@ router.get('/customers/:id/interactions', requireAuth, crmController.getInteract
 router.post('/customers/:id/interactions', requireAuth, crmController.createInteractionForCustomer);
 router.post('/customers/:id/tags/:tagId', requireAuth, crmController.assignTagToCustomer);
 router.delete('/customers/:id/tags/:tagId', requireAuth, crmController.unassignTagFromCustomer);
+router.post('/customers/:id/convert', requireAuth, crmController.convertCustomerToUser);
 
 // Lead routes
 router.post('/leads', requireAuth, validateStageBody, crmController.createLead);

--- a/frontend/src/services/crmService.ts
+++ b/frontend/src/services/crmService.ts
@@ -106,6 +106,8 @@ export const crmService = {
   updateCustomer: (id: string, data: Partial<Customer>) =>
     api.put(`/customers/${id}`, data).then(res => res.data),
   deleteCustomer: (id: string) => api.delete(`/customers/${id}`),
+  convertCustomer: (id: string, data: { name?: string; email?: string; role?: string }) =>
+    api.post<{ password: string }>(`/customers/${id}/convert`, data).then(res => res.data),
   importCustomers: (file: File) => {
     const form = new FormData();
     form.append('file', file);


### PR DESCRIPTION
## Summary
- allow converting an existing customer into a user account with an auto-generated password
- expose `/customers/:id/convert` endpoint and frontend service method
- add UI in Customers page to fill user info, convert, and copy the generated password

## Testing
- `npm test` *(fails: Cannot find module '../../controllers/customDomainController'...)*
- `npm run lint` *(fails: 188 problems (170 errors, 18 warnings))*


------
https://chatgpt.com/codex/tasks/task_e_68b6df69c300832f9ca351603b551ea1