### PR TITLE
feat: add interaction file attachments

### DIFF
--- a/backend/migrations/20250325000000-add-attachment-path-to-interactions.js
+++ b/backend/migrations/20250325000000-add-attachment-path-to-interactions.js
@@ -1,0 +1,14 @@
+'use strict';
+
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.addColumn('interactions', 'attachmentPath', {
+      type: Sequelize.STRING,
+      allowNull: true,
+    });
+  },
+
+  async down(queryInterface, Sequelize) {
+    await queryInterface.removeColumn('interactions', 'attachmentPath');
+  }
+};

--- a/backend/models/Interaction.js
+++ b/backend/models/Interaction.js
@@ -19,6 +19,10 @@ const Interaction = sequelize.define('Interaction', {
     type: DataTypes.TEXT,
     allowNull: true
   },
+  attachmentPath: {
+    type: DataTypes.STRING,
+    allowNull: true
+  },
   userId: {
     type: DataTypes.INTEGER,
     allowNull: false,

--- a/backend/routes/crmRoutes.js
+++ b/backend/routes/crmRoutes.js
@@ -37,7 +37,7 @@ router.delete('/customers/:id', requireAuth, crmController.deleteCustomer);
 router.post('/customers/import', requireAuth, uploadService.upload.single('file'), crmController.importCustomers);
 router.get('/customers/export', requireAuth, crmController.exportCustomers);
 router.get('/customers/:id/interactions', requireAuth, crmController.getInteractionsByCustomer);
-router.post('/customers/:id/interactions', requireAuth, crmController.createInteractionForCustomer);
+router.post('/customers/:id/interactions', requireAuth, uploadService.upload.single('file'), crmController.createInteractionForCustomer);
 router.post('/customers/:id/tags/:tagId', requireAuth, crmController.assignTagToCustomer);
 router.delete('/customers/:id/tags/:tagId', requireAuth, crmController.unassignTagFromCustomer);
 router.post('/customers/:id/convert', requireAuth, crmController.convertCustomerToUser);
@@ -53,7 +53,7 @@ router.post('/leads/:id/convert', requireAuth, crmController.convertLeadToCustom
 router.post('/leads/import', requireAuth, uploadService.upload.single('file'), crmController.importLeads);
 router.get('/leads/export', requireAuth, crmController.exportLeads);
 router.get('/leads/:id/interactions', requireAuth, crmController.getInteractionsByLead);
-router.post('/leads/:id/interactions', requireAuth, crmController.createInteractionForLead);
+router.post('/leads/:id/interactions', requireAuth, uploadService.upload.single('file'), crmController.createInteractionForLead);
 router.post('/leads/:id/tags/:tagId', requireAuth, crmController.assignTagToLead);
 router.delete('/leads/:id/tags/:tagId', requireAuth, crmController.unassignTagFromLead);
 
@@ -64,10 +64,10 @@ router.put('/tags/:id', requireAuth, crmController.updateTag);
 router.delete('/tags/:id', requireAuth, crmController.deleteTag);
 
 // Interaction routes
-router.post('/interactions', requireAuth, crmController.createInteraction);
+router.post('/interactions', requireAuth, uploadService.upload.single('file'), crmController.createInteraction);
 router.get('/interactions', requireAuth, crmController.getInteractions);
 router.get('/interactions/:id', requireAuth, crmController.getInteractionById);
-router.put('/interactions/:id', requireAuth, crmController.updateInteraction);
+router.put('/interactions/:id', requireAuth, uploadService.upload.single('file'), crmController.updateInteraction);
 router.delete('/interactions/:id', requireAuth, crmController.deleteInteraction);
 
 module.exports = router;

--- a/crm.sql
+++ b/crm.sql
@@ -34,6 +34,7 @@ CREATE TABLE IF NOT EXISTS `interactions` (
   `type` VARCHAR(255) NOT NULL,
   `date` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
   `notes` TEXT,
+  `attachmentPath` VARCHAR(255) DEFAULT NULL,
   `userId` INT NOT NULL,
   `customerId` INT DEFAULT NULL,
   `leadId` INT DEFAULT NULL,

--- a/frontend/src/components/InteractionForm.tsx
+++ b/frontend/src/components/InteractionForm.tsx
@@ -9,6 +9,7 @@ interface InteractionFormProps {
 
 const InteractionForm: React.FC<InteractionFormProps> = ({ entityId, entityType, onSaved }) => {
   const [form, setForm] = useState({ type: '', date: '', notes: '' });
+  const [file, setFile] = useState<File | null>(null);
   const [loading, setLoading] = useState(false);
 
   const handleChange = (
@@ -17,12 +18,17 @@ const InteractionForm: React.FC<InteractionFormProps> = ({ entityId, entityType,
     setForm({ ...form, [e.target.name]: e.target.value });
   };
 
+  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setFile(e.target.files?.[0] || null);
+  };
+
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     setLoading(true);
     try {
-      await crmService.createInteraction(entityType, entityId, form);
+      await crmService.createInteraction(entityType, entityId, { ...form, file: file || undefined });
       setForm({ type: '', date: '', notes: '' });
+      setFile(null);
       onSaved?.();
     } catch (error) {
       console.error('Failed to save interaction:', error);
@@ -54,6 +60,12 @@ const InteractionForm: React.FC<InteractionFormProps> = ({ entityId, entityType,
         className="w-full p-2 border rounded"
         rows={4}
         placeholder="Notes"
+      />
+      <input
+        type="file"
+        name="file"
+        onChange={handleFileChange}
+        className="w-full p-2 border rounded"
       />
       <button
         type="submit"

--- a/frontend/src/pages/InteractionForm.tsx
+++ b/frontend/src/pages/InteractionForm.tsx
@@ -203,6 +203,7 @@ const InteractionsPage: React.FC = () => {
   // edit modal
   const [editingInteraction, setEditingInteraction] = useState<Interaction | null>(null);
   const [editForm, setEditForm] = useState({ type: '', date: '', notes: '' });
+  const [editFile, setEditFile] = useState<File | null>(null);
 
   // filters / sort / view
   const [search, setSearch] = useState('');
@@ -244,18 +245,23 @@ const InteractionsPage: React.FC = () => {
       date: interaction.date || '',
       notes: interaction.notes || ''
     });
+    setEditFile(null);
   };
   const handleEditChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
     setEditForm((p) => ({ ...p, [e.target.name]: e.target.value }));
+  };
+  const handleEditFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setEditFile(e.target.files?.[0] || null);
   };
   const handleEditSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     if (!editingInteraction) return;
     setBusy(true);
     try {
-      const updated = await crmService.updateInteraction(editingInteraction.id, editForm);
+      const updated = await crmService.updateInteraction(editingInteraction.id, { ...editForm, file: editFile || undefined });
       setInteractions((arr) => arr.map((i) => (i.id === editingInteraction.id ? updated : i)));
       setEditingInteraction(null);
+      setEditFile(null);
     } catch (error) {
       console.error('Failed to update interaction', error);
     } finally {
@@ -492,6 +498,18 @@ const InteractionsPage: React.FC = () => {
                       </Td>
                       <Td className="text-gray-600 dark:text-gray-300">
                         <div className="max-w-[52ch] line-clamp-2">{interaction.notes || '—'}</div>
+                        {interaction.attachmentPath && (
+                          <div>
+                            <a
+                              href={interaction.attachmentPath}
+                              target="_blank"
+                              rel="noopener noreferrer"
+                              className="text-blue-600 hover:underline text-sm"
+                            >
+                              Attachment
+                            </a>
+                          </div>
+                        )}
                       </Td>
                       <Td className="text-right">
                         <div className="flex justify-end gap-2">
@@ -567,6 +585,16 @@ const InteractionsPage: React.FC = () => {
                         </div>
                       </div>
                       {i.notes && <p className="mt-2 text-sm text-gray-700 dark:text-gray-300 whitespace-pre-wrap">{i.notes}</p>}
+                      {i.attachmentPath && (
+                        <a
+                          href={i.attachmentPath}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="mt-1 block text-sm text-blue-600 hover:underline"
+                        >
+                          Attachment
+                        </a>
+                      )}
                     </div>
                   </li>
                 ))}
@@ -626,6 +654,20 @@ const InteractionsPage: React.FC = () => {
             onChange={handleEditChange}
             placeholder="Details…"
           />
+          {editingInteraction?.attachmentPath && (
+            <div className="text-sm">
+              Current file:{' '}
+              <a
+                href={editingInteraction.attachmentPath}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-blue-600 hover:underline"
+              >
+                Download
+              </a>
+            </div>
+          )}
+          <Input type="file" name="file" label="Attachment" onChange={handleEditFileChange} />
         </form>
       </Modal>
 

--- a/frontend/src/services/crmService.ts
+++ b/frontend/src/services/crmService.ts
@@ -50,6 +50,7 @@ export interface Interaction {
   notes?: string;
   customerId?: string;
   leadId?: string;
+  attachmentPath?: string;
   createdAt?: string;
 }
 
@@ -141,12 +142,34 @@ export const crmService = {
   createInteraction: (
     entity: 'customers' | 'leads',
     id: string,
-    data: { type: string; date?: string; notes?: string }
-  ) => api.post(`/${entity}/${id}/interactions`, data).then(res => res.data),
+    data: { type: string; date?: string; notes?: string; file?: File }
+  ) => {
+    const form = new FormData();
+    form.append('type', data.type);
+    if (data.date) form.append('date', data.date);
+    if (data.notes) form.append('notes', data.notes);
+    if (data.file) form.append('file', data.file);
+    return api
+      .post(`/${entity}/${id}/interactions`, form, {
+        headers: { 'Content-Type': 'multipart/form-data' },
+      })
+      .then(res => res.data);
+  },
   updateInteraction: (
     id: string,
-    data: { type?: string; date?: string; notes?: string }
-  ) => api.put(`/interactions/${id}`, data).then(res => res.data),
+    data: { type?: string; date?: string; notes?: string; file?: File }
+  ) => {
+    const form = new FormData();
+    if (data.type) form.append('type', data.type);
+    if (data.date) form.append('date', data.date);
+    if (data.notes) form.append('notes', data.notes);
+    if (data.file) form.append('file', data.file);
+    return api
+      .put(`/interactions/${id}`, form, {
+        headers: { 'Content-Type': 'multipart/form-data' },
+      })
+      .then(res => res.data);
+  },
   deleteInteraction: (id: string) => api.delete(`/interactions/${id}`),
 };
 


### PR DESCRIPTION
## Summary
- add attachmentPath column and migration for interactions
- accept file uploads on interaction endpoints
- handle attachment files on the frontend and service layer

## Testing
- `npm test` (backend) *(fails: Cannot find module 'csv-parser' etc.)*
- `npm test` (frontend) *(fails: Missing script "test")*
- `npm run lint` (frontend) *(fails: 188 problems)*

------
https://chatgpt.com/codex/tasks/task_e_68b6e1e556f8832f86773ad3534608d4