### PR TITLE
Track lead stage history and conversion timing

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -1,1 +1,41 @@
-# PFE-Backend
+# Backend
+
+## CRM Stats Endpoint
+
+`GET /crm/stats` returns aggregated CRM metrics including lead and customer counts,
+conversion rates, and timing information.
+
+### Sample response
+
+```json
+{
+  "leadCount": 5,
+  "customerCount": 3,
+  "conversionRate": 0.38,
+  "weeklyLeadCreation": [
+    { "week": "2024-20", "count": 2 }
+  ],
+  "interactionsPerCustomer": [
+    { "customerId": 1, "name": "Alice", "count": 4 }
+  ],
+  "stageCounts": {
+    "new": 1,
+    "contacted": 2
+  },
+  "stageConversionRates": {
+    "new": 0.2,
+    "contacted": 0.4
+  },
+  "avgConversionDays": 7.5,
+  "avgStageDuration": {
+    "new": 2.0,
+    "contacted": 3.5,
+    "qualified": 1.0,
+    "proposal": 0,
+    "won": 0
+  }
+}
+```
+
+All duration metrics are expressed in days.
+

--- a/backend/models/Customer.js
+++ b/backend/models/Customer.js
@@ -44,6 +44,22 @@ const Customer = sequelize.define('Customer', {
       key: 'id'
     },
     onDelete: 'SET NULL'
+  },
+  stageTimestamps: {
+    type: DataTypes.JSON,
+    allowNull: true,
+    field: 'stage_timestamps',
+    defaultValue: {},
+  },
+  convertedAt: {
+    type: DataTypes.DATE,
+    allowNull: true,
+    field: 'converted_at',
+  },
+  leadCreatedAt: {
+    type: DataTypes.DATE,
+    allowNull: true,
+    field: 'lead_created_at',
   }
 }, {
   tableName: 'customers',

--- a/backend/models/Lead.js
+++ b/backend/models/Lead.js
@@ -28,6 +28,12 @@ const Lead = sequelize.define('Lead', {
     allowNull: false,
     defaultValue: 'new'
   },
+  stageTimestamps: {
+    type: DataTypes.JSON,
+    allowNull: true,
+    field: 'stage_timestamps',
+    defaultValue: {},
+  },
   userId: {
     type: DataTypes.INTEGER,
     allowNull: false,


### PR DESCRIPTION
## Summary
- record stage timestamps for leads and conversion info for customers
- compute average lead conversion time and per-stage durations in `/crm/stats`
- document sample stats response

## Testing
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b6ec2ce134832fbc963b9dc541375f