### PR TITLE
fix: refresh tables after deleting leads or customers

### DIFF
--- a/frontend/src/pages/CustomersPage.tsx
+++ b/frontend/src/pages/CustomersPage.tsx
@@ -301,7 +301,8 @@ const CustomersPage: React.FC = () => {
     setBusy(true);
     try {
       await crmService.deleteCustomer(id);
-      setCustomers((cs) => cs.filter((c) => c.id !== id));
+      // Ensure we compare ids as strings in case the backend returns numeric ids
+      setCustomers((cs) => cs.filter((c) => String(c.id) !== String(id)));
       setShowDelete({ open: false });
     } catch (error) {
       console.error('Failed to delete customer', error);
@@ -327,7 +328,8 @@ const CustomersPage: React.FC = () => {
     setBusy(true);
     try {
       const res = await crmService.convertCustomer(showConvert.id, convertForm);
-      setCustomers((cs) => cs.filter((c) => c.id !== showConvert.id));
+      // Filter using string comparison to handle numeric ids
+      setCustomers((cs) => cs.filter((c) => String(c.id) !== String(showConvert.id)));
       setGeneratedPassword(res.password);
     } catch (error) {
       console.error('Failed to convert customer', error);

--- a/frontend/src/pages/LeadsPage.tsx
+++ b/frontend/src/pages/LeadsPage.tsx
@@ -376,7 +376,8 @@ const LeadsPage: React.FC = () => {
     setBusy(true);
     try {
       await crmService.deleteLead(id);
-      setLeads((ls) => ls.filter((l) => l.id !== id));
+      // Compare ids as strings to ensure the deleted lead is removed even if ids are numeric
+      setLeads((ls) => ls.filter((l) => String(l.id) !== String(id)));
       setShowDelete({ open: false });
     } catch (error) {
       console.error('Failed to delete lead', error);
@@ -389,7 +390,8 @@ const LeadsPage: React.FC = () => {
     setBusy(true);
     try {
       await crmService.convertLead(id);
-      setLeads((ls) => ls.filter((l) => l.id !== id));
+      // Use string comparison in case lead ids are returned as numbers from the API
+      setLeads((ls) => ls.filter((l) => String(l.id) !== String(id)));
       setShowConvert({ open: false });
       navigate(`${basePath}/crm/customers`);
     } catch (error) {


### PR DESCRIPTION
## Summary
- ensure deleting a customer updates the displayed table
- ensure deleting or converting a lead updates the displayed table

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: 189 problems)


------
https://chatgpt.com/codex/tasks/task_e_68b6fd5eb580832f9496fb56740b0f74